### PR TITLE
support for global assets

### DIFF
--- a/morpheus-infoblox-plugin/src/main/groovy/com/morpheusdata/infoblox/InfobloxProvider.groovy
+++ b/morpheus-infoblox-plugin/src/main/groovy/com/morpheusdata/infoblox/InfobloxProvider.groovy
@@ -47,7 +47,6 @@ class InfobloxProvider implements IPAMProvider, DNSProvider {
 		this.infobloxAPI = api
 	}
 
-	@Override
 	ServiceResponse provisionWorkload(AccountIntegration integration, Workload workload, Map opts) {
 		return null
 	}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/AbstractInstanceTabProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/AbstractInstanceTabProvider.java
@@ -1,5 +1,6 @@
 package com.morpheusdata.core;
 
+import com.morpheusdata.model.UIScope;
 import com.morpheusdata.views.HandlebarsRenderer;
 import com.morpheusdata.views.Renderer;
 
@@ -18,5 +19,10 @@ public abstract class AbstractInstanceTabProvider implements InstanceTabProvider
 			renderer.registerAssetHelper(getPlugin().getName());
 		}
 		return renderer;
+	}
+
+	@Override
+	public UIScope getContentScope() {
+		return UIScope.instanceTab;
 	}
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/InstanceTabProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/InstanceTabProvider.java
@@ -1,10 +1,7 @@
 package com.morpheusdata.core;
 
 
-import com.morpheusdata.model.Account;
-import com.morpheusdata.model.Instance;
-import com.morpheusdata.model.TabContentSecurityPolicy;
-import com.morpheusdata.model.User;
+import com.morpheusdata.model.*;
 import com.morpheusdata.views.HTMLResponse;
 import com.morpheusdata.views.Renderer;
 
@@ -43,5 +40,12 @@ public interface InstanceTabProvider extends PluginProvider {
 	 *
 	 * @return policy directives for various source types
 	 */
-	TabContentSecurityPolicy getContentSecurityPolicy();
+	ContentSecurityPolicy getContentSecurityPolicy();
+
+	/**
+	 * Define the scope of this UI element (e.g. global, tab, etc.)
+	 *
+	 * @return scope
+	 */
+	UIScope getContentScope();
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ContentSecurityPolicy.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ContentSecurityPolicy.java
@@ -6,7 +6,7 @@ package com.morpheusdata.model;
  * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy">Content Security Policy Header</a>
  * @author Mike Truso
  */
-public class TabContentSecurityPolicy {
+public class ContentSecurityPolicy {
 
 	/**
 	 * CSP frame-src directive
@@ -31,4 +31,10 @@ public class TabContentSecurityPolicy {
 	 * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/style-src">style-src directive</a>
 	 */
 	public String styleSrc;
+
+	/**
+	 * CSP connect-src directive
+	 * @see <a href="https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/connect-src">style-src directive</a>
+	 */
+	public String connectSrc;
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/UIScope.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/UIScope.java
@@ -1,0 +1,6 @@
+package com.morpheusdata.model;
+
+public enum UIScope {
+	global,
+	instanceTab
+}

--- a/samples/morpheus-tab-plugin/src/main/groovy/com/morpheusdata/tab/CustomTabProvider.groovy
+++ b/samples/morpheus-tab-plugin/src/main/groovy/com/morpheusdata/tab/CustomTabProvider.groovy
@@ -5,9 +5,8 @@ import com.morpheusdata.core.MorpheusContext
 import com.morpheusdata.core.Plugin
 import com.morpheusdata.model.Account
 import com.morpheusdata.model.Instance
-import com.morpheusdata.model.Permission
 import com.morpheusdata.model.TaskConfig
-import com.morpheusdata.model.TabContentSecurityPolicy
+import com.morpheusdata.model.ContentSecurityPolicy
 import com.morpheusdata.model.User
 import com.morpheusdata.views.HTMLResponse
 import com.morpheusdata.views.ViewModel
@@ -74,8 +73,8 @@ class CustomTabProvider extends AbstractInstanceTabProvider {
 	 * @return
 	 */
 	@Override
-	TabContentSecurityPolicy getContentSecurityPolicy() {
-		def csp = new TabContentSecurityPolicy()
+	ContentSecurityPolicy getContentSecurityPolicy() {
+		def csp = new ContentSecurityPolicy()
 		csp.scriptSrc = '*.jsdelivr.net'
 		csp.frameSrc = '*.digitalocean.com'
 		csp.imgSrc = '*.wikimedia.org'


### PR DESCRIPTION
Providers with a `UIScope.global` will call `renderTemplate` and be rendered at the bottom of the Morpheus UI. This allows for extending Whitelabel settings to provide your own global html/css/js. 