### PR TITLE
[PCCP-1954] Enhance OS-specific hostname formatting

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/ComputeUtility.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/ComputeUtility.java
@@ -50,6 +50,8 @@ public class ComputeUtility {
 		String rtn = name;
 		if(rtn != null) {
 			rtn = rtn.replaceAll("\\W+","-");
+			// Underscores are not valid in hostnames, so replace with hyphen
+			rtn = rtn.replaceAll("_", "-");
 			// After all of the above, we should not begin or end with a hyphen as
 			// that is not valid for either linux or windows hostname
 			rtn = rtn.replaceAll("^-|-$", "");
@@ -71,6 +73,8 @@ public class ComputeUtility {
 			rtn = rtn.replaceAll("\\W+", "-");
 			rtn = rtn.replaceAll("\'", "");
 			rtn = rtn.replaceAll(",", "");
+			// Underscores are not valid in hostnames, so replace with hyphen
+			rtn = rtn.replaceAll("_", "-");
 			// After all of the above, we should not begin or end with a hyphen as
 			// that is not valid for either linux or windows hostname
 			rtn = rtn.replaceAll("^-|-$", "");

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/ComputeUtility.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/ComputeUtility.java
@@ -50,6 +50,9 @@ public class ComputeUtility {
 		String rtn = name;
 		if(rtn != null) {
 			rtn = rtn.replaceAll("\\W+","-");
+			// After all of the above, we should not begin or end with a hyphen as
+			// that is not valid for either linux or windows hostname
+			rtn = rtn.replaceAll("^-|-$", "");
 			rtn = rtn.toLowerCase();
 			if(platform == PlatformType.windows) {
 				rtn = rtn.substring(0, Math.min(rtn.length(), 15));
@@ -68,6 +71,9 @@ public class ComputeUtility {
 			rtn = rtn.replaceAll("\\W+", "-");
 			rtn = rtn.replaceAll("\'", "");
 			rtn = rtn.replaceAll(",", "");
+			// After all of the above, we should not begin or end with a hyphen as
+			// that is not valid for either linux or windows hostname
+			rtn = rtn.replaceAll("^-|-$", "");
 			rtn = rtn.toLowerCase();
 		}
 

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/util/ComputeUtilitySpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/util/ComputeUtilitySpec.groovy
@@ -16,6 +16,7 @@ class ComputeUtilitySpec extends Specification {
 		"api.maas'foo"   | PlatformType.linux   || 'api-maas-foo'
 		"api.maas'foo"   | PlatformType.linux   || 'api-maas-foo'
 		"api.maas'foo--" | PlatformType.windows || 'api-maas-foo'
+		"@Fi-)~!mnaeif@.com" | PlatformType.linux   || 'fi-mnaeif-com'
 	}
 
 	void "formatProvisionHostname"() {

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/util/ComputeUtilitySpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/util/ComputeUtilitySpec.groovy
@@ -9,14 +9,15 @@ class ComputeUtilitySpec extends Specification {
 		expected == ComputeUtility.formatHostname(host, platform)
 
 		where:
-		host             | platform             || expected
-		'MAAS'           | PlatformType.linux   || 'maas'
-		'api.maas'       | PlatformType.linux   || 'api-maas'
-		'api.maas,foo'   | PlatformType.linux   || 'api-maas-foo'
-		"api.maas'foo"   | PlatformType.linux   || 'api-maas-foo'
-		"api.maas'foo"   | PlatformType.linux   || 'api-maas-foo'
-		"api.maas'foo--" | PlatformType.windows || 'api-maas-foo'
+		host                 | platform             || expected
+		'MAAS'               | PlatformType.linux   || 'maas'
+		'api.maas'           | PlatformType.linux   || 'api-maas'
+		'api.maas,foo'       | PlatformType.linux   || 'api-maas-foo'
+		"api.maas'foo"       | PlatformType.linux   || 'api-maas-foo'
+		"api.maas'foo"       | PlatformType.linux   || 'api-maas-foo'
+		"api.maas'foo--"     | PlatformType.windows || 'api-maas-foo'
 		"@Fi-)~!mnaeif@.com" | PlatformType.linux   || 'fi-mnaeif-com'
+		"9_7_25_4"           | PlatformType.linux   || '9-7-25-4'
 	}
 
 	void "formatProvisionHostname"() {


### PR DESCRIPTION
There is existing logic to format the Instance name to platform-specific hostname. However it was allowing beginning and ending hyphens. Added that additional replacement to the existing code.
