### PR TITLE
[PCCP-3753] Added updateVolume method to StorageProviderVolumes

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
@@ -195,15 +195,6 @@ public interface DatastoreTypeProvider extends PluginProvider {
 	ServiceResponse<StorageVolume> resizeVolume(StorageVolume volume, ComputeServer server, Long newSize);
 
 	/**
-	 * Perform any operations necessary on the target to update a volume. This is used to update a volume on a storage server
-	 * @param currentVolume the current volume to edit
-	 * @param server the server the volume is being edited on (may contain information such as parentServer (hypervisor) or cluster)
-	 * @param opts additional options
-	 * @return the success state and a copy of the volume
-	 */
-	ServiceResponse<StorageVolume> updateVolume(StorageVolume currentVolume, ComputeServer server, Map opts);
-
-	/**
 	 * Perform any validations necessary on the target prior to create. The default returns success.
 	 * @param datastore the current datastore being created
 	 * @return the service response containing success state or any errors upon failure

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
@@ -25,6 +25,7 @@ import com.morpheusdata.response.ServiceResponse;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents a DatastoreType and how a {@link StorageServer} interacts with various provisioners
@@ -192,6 +193,15 @@ public interface DatastoreTypeProvider extends PluginProvider {
 	 * @return the success state and a copy of the volume
 	 */
 	ServiceResponse<StorageVolume> resizeVolume(StorageVolume volume, ComputeServer server, Long newSize);
+
+	/**
+	 * Perform any operations necessary on the target to update a volume. This is used to update a volume on a storage server
+	 * @param currentVolume the current volume to edit
+	 * @param server the server the volume is being edited on (may contain information such as parentServer (hypervisor) or cluster)
+	 * @param opts additional options
+	 * @return the success state and a copy of the volume
+	 */
+	ServiceResponse<StorageVolume> updateVolume(StorageVolume currentVolume, ComputeServer server, Map opts);
 
 	/**
 	 * Perform any validations necessary on the target prior to create. The default returns success.

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
@@ -25,7 +25,6 @@ import com.morpheusdata.response.ServiceResponse;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
 
 /**
  * Represents a DatastoreType and how a {@link StorageServer} interacts with various provisioners

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderVolumes.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderVolumes.java
@@ -36,12 +36,16 @@ import java.util.Map;
 public interface StorageProviderVolumes {
 	ServiceResponse<StorageVolume> createVolume(StorageGroup storageGroup, StorageVolume storageVolume, Map opts);
 	ServiceResponse<StorageVolume> resizeVolume(StorageGroup storageGroup, StorageVolume storageVolume, Map opts);
+	ServiceResponse<StorageVolume> updateVolume(StorageGroup storageGroup, StorageVolume storageVolume, Map opts);
 	ServiceResponse<StorageVolume> deleteVolume(StorageGroup storageGroup, StorageVolume storageVolume, Map opts);
 
 	default ServiceResponse createVolume(StorageServer storageServer, StorageVolume storageVolume, Map opts){
 		return ServiceResponse.success();
 	};
 	default ServiceResponse<StorageVolume> resizeVolume(StorageServer storageServer, StorageVolume storageVolume, Map opts){
+		return ServiceResponse.success();
+	};
+	default ServiceResponse<StorageVolume> updateVolume(StorageServer storageServer, StorageVolume storageVolume, Map opts){
 		return ServiceResponse.success();
 	};
 	default ServiceResponse<StorageVolume> deleteVolume(StorageServer storageServer, StorageVolume storageVolume, Map opts){


### PR DESCRIPTION
- [PCCP-3753](https://hpe.atlassian.net/browse/PCCP-3753) - Ability to edit a storage volume
- [PCCP-4802](https://hpe.atlassian.net/browse/PCCP-4802) - QA: Storage Plugin: Unable to rename volumes

This adds support for `updateVolume` in `StorageProviderVolumes`.