### PR TITLE
PCCP-5439: Load Balancer additional interface methods

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/loadbalancer/LoadBalancerProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/loadbalancer/LoadBalancerProvider.java
@@ -16,6 +16,7 @@
 
 package com.morpheusdata.core.network.loadbalancer;
 
+import com.morpheusdata.core.providers.CloudProvider;
 import com.morpheusdata.core.providers.PluginProvider;
 import com.morpheusdata.model.*;
 import com.morpheusdata.response.ServiceResponse;
@@ -55,6 +56,15 @@ public interface LoadBalancerProvider extends PluginProvider {
 	 * @return Collection of NetworkLoadBalancerType
 	 */
 	Collection<NetworkLoadBalancerType> getLoadBalancerTypes();
+
+	/**
+	 * Some older clouds have a load balancer server type code that is the exact same as the cloud code. This allows one to set it
+	 * to match and in doing so the provider will be fetched via the cloud providers {@link CloudProvider#getDefaultLoadBalancerTypeCode()} method.
+	 * @return code for overriding the ProvisionType record code property
+	 */
+	default String getLoadBalancerServerTypeCode() {
+		return getCode();
+	}
 
 	/**
 	 * Validates the user submitted load balancer connection information to ensure the appliance can communicate with it.

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/CloudProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/CloudProvider.java
@@ -17,6 +17,7 @@
 package com.morpheusdata.core.providers;
 
 import com.morpheusdata.core.NetworkProvider;
+import com.morpheusdata.core.network.loadbalancer.LoadBalancerProvider;
 import com.morpheusdata.core.Plugin;
 import com.morpheusdata.model.*;
 import com.morpheusdata.request.FilterServicePlansCriteria;
@@ -345,6 +346,12 @@ public interface CloudProvider extends PluginProvider {
 	 */
 	default String getDefaultNetworkServerTypeCode() { return null; }
 
+	/**
+	 * Returns the default load balancer type code for fetching a {@link LoadBalancerProvider} for this cloud.
+	 * This is only really necessary if the load balancer type code is the exact same as the cloud code.
+	 * @return the load balancer provider code
+	 */
+	default String getDefaultLoadBalancerTypeCode() { return null; }
 
 	default ServiceResponse<CloudPool> createCloudPool(Cloud cloud, CloudPool cloudPool) {
 		return ServiceResponse.success(cloudPool);


### PR DESCRIPTION
Defined interface methods on load balancer to enable routing calls to plugin load balancer provider based on serverTypeCode. This is needed in cases where the CODE of the Cloud and the LB are the same.