### PR TITLE
PCCP-7638: Enhance HttpApiClient for Alletra streaming API support [DO NOT REVIEW]

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/HttpApiClient.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/HttpApiClient.java
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2024 Morpheus Data, LLC.
+ *  Copyright 2024-2025 Morpheus Data, LLC.
  *
  * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
  * you may not use this file except in compliance with the License.
@@ -527,6 +527,37 @@ public class HttpApiClient {
 	}
 
 	/**
+	 * Executes an HTTP request with streaming capabilities to a specified URL and path with JSON response data. This method is intended for
+	 * scenarios where large amounts of data need to be transferred, such as uploading or downloading files, without
+	 * fully loading the data into memory. The method handles authentication and custom request options, and returns
+	 * the raw HTTP response for further processing.
+	 *
+	 * @param url The base URL of the server to which the request is sent. This should include the protocol (e.g., "https://"). Any path or query params
+	 *            included in the URL will be maintained when appending the path and query params supplied in other arguments in this method.
+	 * @param path The specific path or endpoint on the server to which the request is made. This path is appended to the base URL.
+	 * @param username The username used for basic authentication with the server. This can be null if authentication is not required.
+	 * @param password The password used for basic authentication with the server. This should match the provided username. Can be null if authentication is not required.
+	 * @param opts The {@link RequestOptions} object containing various options for the request, such as headers, query parameters, and the request body. The Request body
+	 *             can be one of {@link Map}, {@link String}, byte[], or {@link InputStream}.
+	 * @param method The HTTP method to be used for the request, one of "HEAD", "GET", "POST", "PUT", "PATCH", or "DELETE".
+	 * @return A {@link ServiceResponse} containing the {@link CloseableHttpResponse} from the server. This response
+	 *         can be used to read the server's response, including status codes, headers, and content.
+	 * @throws URISyntaxException If the provided URL or path is invalid or cannot be correctly parsed into a URI.
+	 * @throws Exception If an error occurs during the execution of the request, such as an I/O error, authentication failure, or invalid response.
+	 */
+	public ServiceResponse callStreamJsonApi(
+			String url,
+			final String path,
+			String username,
+			String password,
+			RequestOptions opts,
+			String method
+	) throws URISyntaxException, Exception {
+		ServiceResponse rtn = callStreamApi(url, path, username, password, opts, method);
+		return parseJsonResponse(rtn);
+	}
+
+	 /**
 	 * Executes an HTTP request with streaming capabilities to a specified URL and path. This method is intended for
 	 * scenarios where large amounts of data need to be transferred, such as uploading or downloading files, without
 	 * fully loading the data into memory. The method handles authentication and custom request options, and returns
@@ -615,8 +646,10 @@ public class HttpApiClient {
 			}
 
 			// Headers
-			if (opts.headers == null || opts.headers.isEmpty() || !opts.headers.containsKey("Content-Type")) {
-				request.addHeader("Content-Type", "application/json");
+			if (opts.binaryBodyFilename == null) {
+				if (opts.headers == null || opts.headers.isEmpty() || !opts.headers.containsKey("Content-Type")) {
+					request.addHeader("Content-Type", "application/json");
+				}
 			}
 
 			if (opts.headers != null && !opts.headers.isEmpty()) {
@@ -687,7 +720,18 @@ public class HttpApiClient {
 				} else if (opts.body instanceof byte[]) {
 					postRequest.setEntity(new ByteArrayEntity((byte[]) opts.body));
 				} else if (opts.body instanceof InputStream) {
-					postRequest.setEntity(new InputStreamEntity((InputStream) (opts.body), opts.contentLength != null ? opts.contentLength : -1));
+					if (opts.binaryBodyFilename != null) {
+						MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+						builder.addBinaryBody(
+								opts.binaryBodyName.isEmpty() ? "file" : opts.binaryBodyName,
+								(InputStream) (opts.body),
+								ContentType.DEFAULT_BINARY,
+								opts.binaryBodyFilename
+						);
+						postRequest.setEntity(builder.build());
+					} else {
+						postRequest.setEntity(new InputStreamEntity((InputStream) (opts.body), opts.contentLength != null ? opts.contentLength : -1));
+					}
 				} else {
 					postRequest.setEntity(new StringEntity(opts.body.toString()));
 				}
@@ -712,6 +756,7 @@ public class HttpApiClient {
 
 						if (entity != null) {
 							rtn.setData(response);
+							rtn.setContent(EntityUtils.toString(entity));
 							if (!opts.suppressLog) {
 								log.debug("results of SUCCESSFUL call to {}/{}, results: {}", url, path, rtn.getContent());
 							}
@@ -721,9 +766,11 @@ public class HttpApiClient {
 
 
 						rtn.setSuccess(true);
+						rtn.setStatusCode(Integer.toString(response.getStatusLine().getStatusCode()));
 					} else {
 						if (response.getEntity() != null) {
 							rtn.setData(response);
+							rtn.setContent(EntityUtils.toString(response.getEntity()));
 						}
 						rtn.setSuccess(false);
 						rtn.setErrorCode(Integer.toString(response.getStatusLine().getStatusCode()));
@@ -856,6 +903,18 @@ public class HttpApiClient {
 
 		//execute
 		com.morpheusdata.response.ServiceResponse rtn = callApi(url, path, username, password, opts, method);
+		return parseJsonResponse(rtn);
+	}
+
+	/**
+	 * Parse the JSON response from the API and populate the data field of the
+	 * ServiceResponse.
+	 * 
+	 * @param rtn The ServiceResponse object containing the raw content from the
+	 *            API response.
+	 * @return The updated ServiceResponse object with the parsed data.
+	 */
+	private ServiceResponse parseJsonResponse(ServiceResponse rtn) {
 		rtn.setData(new LinkedHashMap());
 
 		if (rtn.getContent() != null && rtn.getContent().length() > 0) {
@@ -1196,6 +1255,16 @@ public class HttpApiClient {
 		 * The query parameters to include in the request.
 		 */
 		public Map<CharSequence, CharSequence> queryParams;
+
+		/**
+		 * Set to filename if InputStream multipart binary body is requested.
+		 */
+		public String binaryBodyFilename = null;
+
+		/**
+		 * The name of the binary body parameter.
+		 */
+		public String binaryBodyName = "file";
 
 		/**
 		 * Suppress logging of the request and response.

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/HttpApiClient.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/HttpApiClient.java
@@ -75,6 +75,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.*;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.InetSocketAddress;
@@ -557,7 +558,7 @@ public class HttpApiClient {
 		return parseJsonResponse(rtn);
 	}
 
-	 /**
+	/**
 	 * Executes an HTTP request with streaming capabilities to a specified URL and path. This method is intended for
 	 * scenarios where large amounts of data need to be transferred, such as uploading or downloading files, without
 	 * fully loading the data into memory. The method handles authentication and custom request options, and returns
@@ -645,8 +646,8 @@ public class HttpApiClient {
 				OauthUtility.signOAuthRequestPlainText(request, opts.oauth.consumerKey, opts.oauth.consumerSecret, opts.oauth.apiKey, opts.oauth.apiSecret, opts);
 			}
 
-			// Headers
-			if (opts.binaryBodyFilename == null) {
+			// Headers (Setting Content-Type here not needed for File uploads; handled in body section)
+			if (!(opts.body instanceof File)) {
 				if (opts.headers == null || opts.headers.isEmpty() || !opts.headers.containsKey("Content-Type")) {
 					request.addHeader("Content-Type", "application/json");
 				}
@@ -720,18 +721,17 @@ public class HttpApiClient {
 				} else if (opts.body instanceof byte[]) {
 					postRequest.setEntity(new ByteArrayEntity((byte[]) opts.body));
 				} else if (opts.body instanceof InputStream) {
-					if (opts.binaryBodyFilename != null) {
-						MultipartEntityBuilder builder = MultipartEntityBuilder.create();
-						builder.addBinaryBody(
-								opts.binaryBodyName.isEmpty() ? "file" : opts.binaryBodyName,
-								(InputStream) (opts.body),
-								ContentType.DEFAULT_BINARY,
-								opts.binaryBodyFilename
-						);
-						postRequest.setEntity(builder.build());
-					} else {
-						postRequest.setEntity(new InputStreamEntity((InputStream) (opts.body), opts.contentLength != null ? opts.contentLength : -1));
-					}
+					postRequest.setEntity(new InputStreamEntity((InputStream) (opts.body), opts.contentLength != null ? opts.contentLength : -1));
+				} else if (opts.body instanceof File) {
+					File file = (File) opts.body;
+					MultipartEntityBuilder builder = MultipartEntityBuilder.create();
+					builder.addBinaryBody(
+							"file",
+							file,
+							ContentType.DEFAULT_BINARY,
+							file.getName()
+					);
+					postRequest.setEntity(builder.build());
 				} else {
 					postRequest.setEntity(new StringEntity(opts.body.toString()));
 				}
@@ -1255,16 +1255,6 @@ public class HttpApiClient {
 		 * The query parameters to include in the request.
 		 */
 		public Map<CharSequence, CharSequence> queryParams;
-
-		/**
-		 * Set to filename if InputStream multipart binary body is requested.
-		 */
-		public String binaryBodyFilename = null;
-
-		/**
-		 * The name of the binary body parameter.
-		 */
-		public String binaryBodyName = "file";
 
 		/**
 		 * Suppress logging of the request and response.


### PR DESCRIPTION
The Alletra MP supports using multipart/form-data upload to send a software update file to the Alletra. The details are available here:

https://pages.github.hpe.com/hpe-3par-mgmt/ssmc-onnode/2.6.0/api/public_and_private/index.html#post-/api/v3/softwareupdate/upload

Because the Morpheus `HttpApiClient` `callStreamApi` did not support the format required by the Alletra, we initially developed our own streaming support which you can see here:

https://github.com/HPE-EMU/morpheus-storage-abstraction/blob/18aca8b4d354feab7ba1851b668000736fc272a5/src/main/groovy/com/hpe/sal/alletra/mp/api/ApiUtils.groovy#L91

This PR enhances the `HttpApiClient` `callStreamApi` such that it can support uploading software updates to the Alletra. Special consideration has been made to avoid any regression issues.

- The JSON unmarshaller that was at the tail end of `callJsonApi` has been separated into a private `parseJsonResponse` member function. This allows the reuse of the code when decoding the JSON response returned from a streamed request sent to the Alletra.
- Added support for `opts.body instanceof File` to support file uploads to the Alletra.
- The `callStreamApi` now populates the `rtn.setContent` on success or failure. It also sets the `StatusCode`. These changes are done to be identical to how the existing `callApi` handler does it. Setting the additional properties enables the `parseJsonResponse` to unmarshal the JSON data.
	
