### PR TITLE
PCCP-6133: Enhance NetworkProvider to support NetworkFirewallRule APIs

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/NetworkProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/NetworkProvider.java
@@ -628,6 +628,52 @@ public interface NetworkProvider extends PluginProvider, UIExtensionProvider {
 	}
 
 	/**
+	 * Validate the submitted NetworkFirewallRule information.
+	 * If a {@link ServiceResponse} is not marked as successful the validation results will be
+	 * bubbled up to the user.
+	 * @param network Network information
+	 * @param rule SecurityGroupRule information
+	 * @param opts additional configuration options.
+	 * @return ServiceResponse
+	 */
+	default ServiceResponse validateNetworkFirewallRule(Network network, SecurityGroupRule rule, Map opts) {
+		return ServiceResponse.success();
+	}
+
+	/**
+	 * Creates the submitted NetworkFirewallRule
+	 * @param network Network information
+	 * @param rule SecurityGroupRule information
+	 * @param opts additional configuration options.
+	 * @return ServiceResponse
+	 */
+	default ServiceResponse createNetworkFirewallRule(Network network, SecurityGroupRule rule, Map opts) {
+		return ServiceResponse.success();
+	}
+
+	/**
+	 * Updates the submitted NetworkFirewallRule.
+	 * @param network Network information
+	 * @param rule SecurityGroupRule information
+	 * @param opts additional configuration options.
+	 * @return ServiceResponse
+	 */
+	default ServiceResponse updateNetworkFirewallRule(Network network, SecurityGroupRule rule, Map opts) {
+		return ServiceResponse.success();
+	}
+
+	/**
+	 * Deletes the submitted NetworkFirewallRule.
+	 * @param network Network information
+	 * @param rule SecurityGroupRule information
+	 * @param opts additional configuration options.
+	 * @return ServiceResponse
+	 */
+	default ServiceResponse deleteNetworkFirewallRule(Network network, SecurityGroupRule rule, Map opts) {
+		return ServiceResponse.success();
+	}
+
+	/**
 	 * This method is called just before a workload is provisioned.  This can be used to perform any pre network
 	 * initialization tasks prior to a VM/Container gets provisioned
 	 * @param workloadRequest


### PR DESCRIPTION
Summary:
In the GCP Plugin, to support the NetworkFirewall operations, the NetworkProvider class should expose the following APIs.

- validateNetworkFirewallRule
- createNetworkFirewallRule
- updateNetworkFirewallRule
- deleteNetworkFirewallRule