### PR TITLE
PCCP-8555: Define and use SecurityGroupRuleTargetType

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/NetworkServerType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/NetworkServerType.java
@@ -16,6 +16,9 @@
 
 package com.morpheusdata.model;
 
+import java.util.ArrayList;
+import java.util.List;
+
 public class NetworkServerType extends MorpheusModel {
 	public String code;
 	public String name;
@@ -61,6 +64,11 @@ public class NetworkServerType extends MorpheusModel {
 	public String titleEdgeClusters;
 	public Boolean hasEdgeClusters = false;
 	protected Boolean hasFloatingIps = false;
+
+	public List<SecurityGroupRuleTargetType> securityGroupRuleIngressDestTypes = new ArrayList<>();
+	public List<SecurityGroupRuleTargetType> securityGroupRuleEgressDestTypes = new ArrayList<>();
+	public List<SecurityGroupRuleTargetType> securityGroupRuleIngressSourceTypes = new ArrayList<>();
+	public List<SecurityGroupRuleTargetType> securityGroupRuleEgressSourceTypes = new ArrayList<>();
 
 	public String getCode() {
 		return code;

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SecurityGroupRuleTargetType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SecurityGroupRuleTargetType.java
@@ -1,0 +1,67 @@
+package com.morpheusdata.model;
+
+public class SecurityGroupRuleTargetType extends MorpheusModel{
+	protected String code;
+	protected String name;
+	protected String value;
+	protected String description;
+	protected String type; //source or destination
+	protected Integer displayOrder;
+	protected Boolean internal = false;
+
+	public String getCode() {
+		return code;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public String getType() {
+		return type;
+	}
+
+	public void setType(String type) {
+		this.type = type;
+	}
+
+	public Integer getDisplayOrder() {
+		return displayOrder;
+	}
+
+	public void setDisplayOrder(Integer displayOrder) {
+		this.displayOrder = displayOrder;
+	}
+
+	public Boolean getInternal() {
+		return internal;
+	}
+
+	public void setInternal(Boolean internal) {
+		this.internal = internal;
+	}
+}


### PR DESCRIPTION
The domain class for NetworkServerType supports various SecurityGroupRuleTargetType lists, while the same is missing in model classes. This is required for Azure plugin support and this PR addresses the same.