### PR TITLE
PCCP-9298: Add support for ResourceSpecTemplate and FileContent Morpheus Services to MorpheusAsyncServices

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusAsyncServices.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusAsyncServices.java
@@ -40,6 +40,7 @@ import com.morpheusdata.core.providers.TaskProvider;
 import com.morpheusdata.core.provisioning.MorpheusProvisionService;
 import com.morpheusdata.model.BackupProvider;
 import com.morpheusdata.core.admin.MorpheusAdminService;
+import com.morpheusdata.core.library.MorpheusResourceSpecTemplateService;
 
 public interface MorpheusAsyncServices {
 	/**
@@ -563,4 +564,16 @@ public interface MorpheusAsyncServices {
 	 * @return an instance of the MorpheusCurrencyConversionService
 	 */
 	MorpheusCurrencyConversionService getCurrency();
+
+	/**
+	 * Returns the {@link MorpheusResourceSpecTemplateService} which allows access to Resource Spec Template operations
+	 * @return an instance of {@link MorpheusResourceSpecTemplateService}
+	 */
+	MorpheusResourceSpecTemplateService getResourceSpecTemplate();
+
+	/**
+	 * Returns the {@link MorpheusFileContentService} which allows access to File Content operations
+	 * @return an instance of {@link MorpheusFileContentService}
+	 */
+	MorpheusFileContentService getFileContent();
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusFileContentService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusFileContentService.java
@@ -1,0 +1,28 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core;
+
+import com.morpheusdata.model.FileContent;
+
+/**
+ * Context methods for managing file content
+ * @author bdwheeler
+ * @since 0.15.1
+ */
+public interface MorpheusFileContentService extends MorpheusDataService<FileContent,FileContent> {
+
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ComputeTypeLayout.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ComputeTypeLayout.java
@@ -32,7 +32,7 @@ public class ComputeTypeLayout extends MorpheusModel {
 	protected Collection<ComputeTypeSet> computeServers;
 	protected ProvisionType provisionType;
 	protected ComputeServerGroupType groupType;
-
+	protected Collection<ResourceSpecTemplate> specTemplates;
 	protected Collection<ComputeTypePackage> packages;
 
 	public String getCode() {


### PR DESCRIPTION
JIRA Story - [[PCCP-9298] Add support for ResourceSpecTemplate and FileContent Morpheus Services to MorpheusAsyncServices and add ResourceSpecTemplate property to ComputeTypeLayout](https://hpe.atlassian.net/browse/PCCP-9298)

- `MorpheusResourceSpecTemplateService` should be added to `MorpheusAsyncServices` interface.
- Implement `MorpheusResourceSpecTemplateImplService` and it’s methods as a part of the `MorpheusAsyncServicesService`.
- Add `ResourceSpecTemplate` property to `ComputeTypeLayout` morpheus data model.
- Implement and add `MorpheusFileContentService` to `MorpheusAsyncServices` interface.
- Implement `MorpheusFileContentService` and it’s methods as a part of the `MorpheusAsyncServicesService`.