### PR TITLE
PCCP-7641: Adding id analyzer annotation to make the filter query work

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SecurityGroupRule.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SecurityGroupRule.java
@@ -31,6 +31,7 @@ import java.util.List;
  */
 public class SecurityGroupRule extends SecurityGroupRuleIdentityProjection {
 
+	@JsonSerialize(using= ModelAsIdOnlySerializer.class)
     protected SecurityGroupIdentityProjection securityGroup;
     protected String groupName; //for things that also group rules into a set
     protected String groupType = "instance"; //firewall,instance,router

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SecurityGroupRuleLocation.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SecurityGroupRuleLocation.java
@@ -23,6 +23,7 @@ import com.morpheusdata.model.serializers.ModelAsIdOnlySerializer;
 
 public class SecurityGroupRuleLocation extends MorpheusModel {
 
+	@JsonSerialize(using= ModelAsIdOnlySerializer.class)
     protected SecurityGroupRuleIdentityProjection securityGroupRule;
     protected String code;
     protected String category;


### PR DESCRIPTION
securityGroup.rule filter is not working, its not able to filter by securityGroup
def sgId = 107
def securityGroup = morpheusContext.services.securityGroup.get(sgId)
List<SecurityGroupRule> sg_rules = morpheusContext.services.securityGroup.rule.list(new DataQuery().withFilters(
                        new DataFilter('securityGroup',  securityGroup)
                ))   // it should return 18 records, instead its returning all 32324 records
mysql> select id, name,security_group_id  from security_group_rule where security_group_id=107;
+-------+--------------+-------------------+
| id    | name         | security_group_id |
+-------+--------------+-------------------+
| 32318 | AafakTest1   |               107 |
| 32319 | AafakTest1   |               107 |
| 32320 | AafakTest555 |               107 |
| 32322 | AafakTest1   |               107 |
| 32323 | AafakTest1   |               107 |
| 32324 | AafakTest555 |               107 |
| 32326 | AafakTest1   |               107 |
| 32327 | AafakTest1   |               107 |
| 32328 | AafakTest555 |               107 |
| 32330 | AafakTest1   |               107 |
| 32331 | AafakTest1   |               107 |
| 32332 | AafakTest555 |               107 |
| 32334 | AafakTest1   |               107 |
| 32335 | AafakTest1   |               107 |
| 32336 | AafakTest555 |               107 |
| 32338 | AafakTest1   |               107 |
| 32339 | AafakTest1   |               107 |
| 32340 | AafakTest555 |               107 |
+-------+--------------+-------------------+
18 rows in set (0.00 sec)
mysql> select count(*) from security_group_rule;
+----------+
| count(*) |
+----------+
|    32324 |
+----------+ (edited) 