### PR TITLE
MORPH-4070: Add filterStorageVolumeTypes method to provider interfaces

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ClusterProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ClusterProvider.java
@@ -352,7 +352,7 @@ public interface ClusterProvider extends PluginProvider {
 	 * @param datastoreType the datastore type to filter for
 	 * @param storageVolumeTypes the collection of storage volume types to filter
 	 * @return a ServiceResponse containing the filtered collection of storage volume types
-	 * @since 1.2.14
+	 * @since 1.3.1
 	 */
 	default ServiceResponse<Collection<StorageVolumeType>> filterStorageVolumeTypes(DatastoreType datastoreType, Collection<StorageVolumeType> storageVolumeTypes) {
 		return ServiceResponse.success(storageVolumeTypes);

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ClusterProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ClusterProvider.java
@@ -344,4 +344,18 @@ public interface ClusterProvider extends PluginProvider {
 		ServiceResponse stopServer(ComputeServer computeServer);
 	}
 
+	/**
+	 * Filter storage volume types based on the datastore type capabilities.
+	 * This allows cluster providers to restrict which storage volume types are compatible with their datastores.
+	 * For example, a datastore may only support certain disk types or configurations.
+	 * 
+	 * @param datastoreType the datastore type to filter for
+	 * @param storageVolumeTypes the collection of storage volume types to filter
+	 * @return a ServiceResponse containing the filtered collection of storage volume types
+	 * @since 1.2.14
+	 */
+	default ServiceResponse<Collection<StorageVolumeType>> filterStorageVolumeTypes(DatastoreType datastoreType, Collection<StorageVolumeType> storageVolumeTypes) {
+		return ServiceResponse.success(storageVolumeTypes);
+	}
+
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
@@ -483,7 +483,7 @@ public interface DatastoreTypeProvider extends PluginProvider {
 	 * @param datastoreType the datastore type to filter for
 	 * @param storageVolumeTypes the collection of storage volume types to filter
 	 * @return a ServiceResponse containing the filtered collection of storage volume types
-	 * @since 1.2.14
+	 * @since 1.3.1
 	 */
 	default ServiceResponse<Collection<StorageVolumeType>> filterStorageVolumeTypes(DatastoreType datastoreType, Collection<StorageVolumeType> storageVolumeTypes) {
 		return ServiceResponse.success(storageVolumeTypes);

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
@@ -25,6 +25,7 @@ import com.morpheusdata.response.ServiceResponse;
 import com.morpheusdata.request.CreateSnapshotRequest;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
 
 /**
@@ -472,6 +473,20 @@ public interface DatastoreTypeProvider extends PluginProvider {
 				IDE
 			}
 		}
+	}
+
+	/**
+	 * Filter storage volume types based on the datastore type capabilities.
+	 * This allows providers to restrict which storage volume types are compatible with their datastore.
+	 * For example, a datastore may only support certain disk types or configurations.
+	 * 
+	 * @param datastoreType the datastore type to filter for
+	 * @param storageVolumeTypes the collection of storage volume types to filter
+	 * @return a ServiceResponse containing the filtered collection of storage volume types
+	 * @since 1.2.14
+	 */
+	default ServiceResponse<Collection<StorageVolumeType>> filterStorageVolumeTypes(DatastoreType datastoreType, Collection<StorageVolumeType> storageVolumeTypes) {
+		return ServiceResponse.success(storageVolumeTypes);
 	}
 
 	/**


### PR DESCRIPTION
This change adds support for filtering storage volume types based on datastore type capabilities. Plugin providers can now implement the filterStorageVolumeTypes method to restrict which storage volume types are compatible with their datastores.

Changes:
- Added filterStorageVolumeTypes() method to DatastoreTypeProvider
- Added filterStorageVolumeTypes() method to ClusterProvider
- Both methods default to returning all storage volume types unchanged

This corresponds to the morpheus-ui PR #3088 which adds volume type filtering support in the UI and API layers.