### PR TITLE
MORPH-757: Add missing model fields and backup service methods for vCenter plugin support

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/MorpheusBackupService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/MorpheusBackupService.java
@@ -24,6 +24,8 @@ import com.morpheusdata.model.BackupProvider;
 import com.morpheusdata.model.projection.AccountIdentity;
 import com.morpheusdata.model.projection.BackupIdentityProjection;
 
+import com.morpheusdata.response.ServiceResponse;
+import com.morpheusdata.model.VirtualImage;
 import io.reactivex.rxjava3.core.Observable;
 import io.reactivex.rxjava3.core.Single;
 import java.util.Collection;
@@ -175,4 +177,30 @@ public interface MorpheusBackupService extends MorpheusDataService<Backup, Backu
 	 * @return the Single Observable containing the working path for the backup result
 	 */
 	Single<String> getBackupWorkingPath(Long backupId, Long backupResultId);
+
+	/**
+	 * Compresses the backup working directory into a zip archive and saves it to the configured backup storage provider.
+	 * This is typically called at the end of {@link BackupExecutionProvider#extractBackup} after the backup data has been
+	 * written to the working path. The result contains metadata needed to update the {@link BackupResult} (bucket,
+	 * directory, archive name, and archive size).
+	 * @param account the {@link AccountIdentity} that owns the backup
+	 * @param workingPath the local directory path containing the backup data to compress and upload
+	 * @param backupId the id of the {@link Backup} object
+	 * @return a Single Observable containing a {@link ServiceResponse} with result metadata: providerType, basePath,
+	 *         targetBucket, targetDirectory, targetArchive, archiveSize
+	 */
+	Single<ServiceResponse> saveBackupResults(AccountIdentity account, String workingPath, Long backupId);
+
+	/**
+	 * Transfers a backup archive from backup storage into a new {@link VirtualImage}, enabling restore-to-new-instance
+	 * workflows. Files are streamed from the backup storage provider into the default virtual image storage location.
+	 * The {@code sourceImage} parameter is optional and, when provided, is used to inherit cloudInit, installAgent,
+	 * and SSH credential settings onto the new image.
+	 * @param account the {@link AccountIdentity} that owns the backup
+	 * @param backupResult the {@link BackupResult} whose archive should be transferred
+	 * @param opts a map of options: {@code imageType} (e.g. 'vmdk'), {@code zoneTypeCode}, {@code osType}, {@code name}
+	 * @param sourceImage optional source {@link VirtualImage} to inherit settings from; may be null
+	 * @return a Single Observable containing a {@link ServiceResponse} whose data is the newly created {@link VirtualImage}
+	 */
+	Single<ServiceResponse<VirtualImage>> transferBackupToVirtualImage(AccountIdentity account, BackupResult backupResult, Map opts, VirtualImage sourceImage);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/backup/MorpheusSynchronousBackupService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/backup/MorpheusSynchronousBackupService.java
@@ -24,7 +24,10 @@ import com.morpheusdata.model.*;
 import com.morpheusdata.model.BackupProvider;
 import com.morpheusdata.model.projection.AccountIdentity;
 import com.morpheusdata.model.projection.BackupIdentityProjection;
+import com.morpheusdata.response.ServiceResponse;
+import com.morpheusdata.model.VirtualImage;
 import io.reactivex.rxjava3.core.Single;
+import java.util.Map;
 
 public interface MorpheusSynchronousBackupService extends MorpheusSynchronousDataService<Backup, BackupIdentityProjection>, MorpheusSynchronousIdentityService<BackupIdentityProjection> {
 
@@ -112,5 +115,30 @@ public interface MorpheusSynchronousBackupService extends MorpheusSynchronousDat
 	 * @return the working path for the backup result
 	 */
 	String getBackupWorkingPath(Long backupId, Long backupResultId);
-	
+
+	/**
+	 * Compresses the backup working directory into a zip archive and saves it to the configured backup storage provider.
+	 * This is typically called at the end of {@link BackupExecutionProvider#extractBackup} after the backup data has been
+	 * written to the working path. The result contains metadata needed to update the {@link BackupResult} (bucket,
+	 * directory, archive name, and archive size).
+	 * @param account the {@link AccountIdentity} that owns the backup
+	 * @param workingPath the local directory path containing the backup data to compress and upload
+	 * @param backupId the id of the {@link Backup} object
+	 * @return a {@link ServiceResponse} with result metadata: providerType, basePath, targetBucket, targetDirectory,
+	 *         targetArchive, archiveSize
+	 */
+	ServiceResponse saveBackupResults(AccountIdentity account, String workingPath, Long backupId);
+
+	/**
+	 * Transfers a backup archive from backup storage into a new {@link VirtualImage}, enabling restore-to-new-instance
+	 * workflows. Files are streamed from the backup storage provider into the default virtual image storage location.
+	 * The {@code sourceImage} parameter is optional and, when provided, is used to inherit cloudInit, installAgent,
+	 * and SSH credential settings onto the new image.
+	 * @param account the {@link AccountIdentity} that owns the backup
+	 * @param backupResult the {@link BackupResult} whose archive should be transferred
+	 * @param opts a map of options: {@code imageType} (e.g. 'vmdk'), {@code zoneTypeCode}, {@code osType}, {@code name}
+	 * @param sourceImage optional source {@link VirtualImage} to inherit settings from; may be null
+	 * @return a {@link ServiceResponse} whose data is the newly created {@link VirtualImage}
+	 */
+	ServiceResponse<VirtualImage> transferBackupToVirtualImage(AccountIdentity account, BackupResult backupResult, Map opts, VirtualImage sourceImage);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/BackupResult.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/BackupResult.java
@@ -97,6 +97,9 @@ public class BackupResult extends MorpheusModel {
 	protected Date dateCreated;
 	protected Date lastUpdated;
 
+	@JsonSerialize(using= ModelAsIdOnlySerializer.class)
+	protected BackupResult linkedBackupResult;
+
 	protected String source;
 	protected Boolean deletable = true;
 
@@ -695,6 +698,15 @@ public class BackupResult extends MorpheusModel {
 	public void setInternalProcessId(Long internalProcessId) {
 		this.internalProcessId = internalProcessId;
 		markDirty("internalProcessId", internalProcessId, this.internalProcessId);
+	}
+
+	public BackupResult getLinkedBackupResult() {
+		return linkedBackupResult;
+	}
+
+	public void setLinkedBackupResult(BackupResult linkedBackupResult) {
+		markDirty("linkedBackupResult", linkedBackupResult, this.linkedBackupResult);
+		this.linkedBackupResult = linkedBackupResult;
 	}
 
 	public String getLocation() {

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/Instance.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/Instance.java
@@ -95,6 +95,10 @@ public class Instance extends InstanceIdentityProjection {
 	@JsonSerialize(using= ModelCollectionAsIdsOnlySerializer.class)
 	protected List<SnapshotIdentityProjection> snapshots = new ArrayList<>();
 
+	public String volumeConfig;
+	public String controllers;
+	public String interfaces;
+
 	public User getCreatedBy() {
 		return createdBy;
 	}
@@ -102,6 +106,33 @@ public class Instance extends InstanceIdentityProjection {
 	public void setCreatedBy(User createdBy) {
 		this.createdBy = createdBy;
 		markDirty("createdBy", createdBy);
+	}
+
+	public String getVolumeConfig() {
+		return volumeConfig;
+	}
+
+	public void setVolumeConfig(String volumeConfig) {
+		this.volumeConfig = volumeConfig;
+		markDirty("volumeConfig", volumeConfig);
+	}
+
+	public String getControllers() {
+		return controllers;
+	}
+
+	public void setControllers(String controllers) {
+		this.controllers = controllers;
+		markDirty("controllers", controllers);
+	}
+
+	public String getInterfaces() {
+		return interfaces;
+	}
+
+	public void setInterfaces(String interfaces) {
+		this.interfaces = interfaces;
+		markDirty("interfaces", interfaces);
 	}
 
 	public String getUuid() {


### PR DESCRIPTION
## MORPH-757: vCenter plugin backup support

### Model changes
- **BackupResult**: Added `linkedBackupResult` field (with `@JsonSerialize` as id-only), matching the existing domain model
- **Instance**: Added `volumeConfig`, `controllers`, and `interfaces` String fields with getters/setters

### Service interface changes
Added to both `MorpheusBackupService` (async) and `MorpheusSynchronousBackupService` (sync):

- **`saveBackupResults(AccountIdentity, String workingPath, Long backupId)`** — Compresses the backup working directory into a zip archive and uploads it to the configured backup storage provider. Returns a `ServiceResponse` with metadata: `providerType`, `basePath`, `targetBucket`, `targetDirectory`, `targetArchive`, `archiveSize`.

- **`transferBackupToVirtualImage(AccountIdentity, BackupResult, Map opts, VirtualImage sourceImage)`** — Transfers a backup archive from storage into a new `VirtualImage`, enabling restore-to-new-instance workflows. The optional `sourceImage` parameter is used to inherit cloudInit/installAgent/SSH settings.

### Note on getBackupStorageProviderConfig
This ticket item was evaluated and **does not require a new API method**. The existing `getBackupStorageBucket(account, backupId)` + `getBackupStorageProvider(storageBucketId)` combination already exposes all the same data a plugin needs.

Companion PR in morpheus-ui: HPE-EMU/morpheus-ui#pending