### PR TITLE
MORPH-760: improve ValidateCloudRequest to support all credential types

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/request/ValidateCloudRequest.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/request/ValidateCloudRequest.java
@@ -42,10 +42,46 @@ public class ValidateCloudRequest {
 	 */
 	public Map opts;
 
+	/**
+	 * Full credential data map. Contains all fields for the credential type in use
+	 * (e.g. username, password, authToken, authPath, authKey, etc.).
+	 * Use {@link #getCredentialUsername()} and {@link #getCredentialPassword()} for
+	 * common fields, or access this map directly for type-specific fields.
+	 */
+	public Map credentialData;
+
 	public ValidateCloudRequest(String credentialUsername, String credentialPassword, String credentialType, Map opts){
 		this.credentialUsername = credentialUsername;
 		this.credentialPassword = credentialPassword;
 		this.credentialType = credentialType;
 		this.opts = opts;
+	}
+
+	public ValidateCloudRequest(Map credentialData, Map opts){
+		this.credentialData = credentialData;
+		this.credentialType = credentialData != null && credentialData.get("type") != null ? credentialData.get("type").toString() : null;
+		this.opts = opts;
+		this.credentialUsername = getCredentialUsername();
+		this.credentialPassword = getCredentialPassword();
+	}
+
+	/**
+	 * Returns the credential username. Falls back to {@link #credentialData} if {@link #credentialUsername} is null.
+	 */
+	public String getCredentialUsername() {
+		if (credentialUsername != null) return credentialUsername;
+		if (credentialData != null && credentialData.get("username") != null)
+			return credentialData.get("username").toString();
+		return null;
+	}
+
+	/**
+	 * Returns the credential password. Falls back to {@link #credentialData} if {@link #credentialPassword} is null.
+	 */
+	public String getCredentialPassword() {
+		if (credentialPassword != null) return credentialPassword;
+		if (credentialData != null && credentialData.get("password") != null)
+			return credentialData.get("password").toString();
+		return null;
 	}
 }


### PR DESCRIPTION
## Summary

`ValidateCloudRequest` previously only exposed `credentialUsername` and `credentialPassword`, making it impossible for cloud plugins to access other credential fields (API tokens, tenant paths, key pairs, etc.) when validating clouds that use non-username/password credential types.

## Changes

**`ValidateCloudRequest.java`**
- Add `credentialData` Map field containing all credential fields resolved by `loadCredentialConfig`
- Add new constructor `ValidateCloudRequest(Map credentialData, Map opts)` that populates `credentialData`, `credentialType`, and the explicit username/password fields in one call
- Add `getCredentialUsername()` and `getCredentialPassword()` convenience getters that fall back to `credentialData` — backwards compatible with existing plugins