### PR TITLE
MORPH-6732 Adds validateRemoveDatastore for plugins

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/DatastoreTypeProvider.java
@@ -240,6 +240,13 @@ public interface DatastoreTypeProvider extends PluginProvider {
 	}
 
 	/**
+	 * Perform any validations necessary on the target prior to remove. The default returns success.
+	 * @param datastore the current datastore being validated for removal
+	 * @return the success state of the validation
+	 */
+	default ServiceResponse validateRemoveDatastore(Datastore datastore) { return ServiceResponse.success(); }
+
+	/**
 	 * Perform any operations necessary on the target to remove a datastore. this method should be implemented
 	 * if {@link DatastoreTypeProvider#getRemovable()} is true. otherwise return null or an error.
 	 * @param datastore the current datastore being removed
@@ -479,7 +486,7 @@ public interface DatastoreTypeProvider extends PluginProvider {
 	 * Filter storage volume types based on the datastore type capabilities.
 	 * This allows providers to restrict which storage volume types are compatible with their datastore.
 	 * For example, a datastore may only support certain disk types or configurations.
-	 * 
+	 *
 	 * @param datastoreType the datastore type to filter for
 	 * @param storageVolumeTypes the collection of storage volume types to filter
 	 * @return a ServiceResponse containing the filtered collection of storage volume types


### PR DESCRIPTION
### Issues
- [MORPH-6732](https://hpe.atlassian.net/browse/MORPH-6732) - Datastore delete error when outstanding Volumes

### Description
This adds the `validateRemoveDatastore` method so that providers can prevent the deletion of a datastore if they want to. The method defaults to `success` if unimplemented.