### PR TITLE
MORPH-4891 Add synchronous copy of BackupProviderService updateStatus

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/backup/MorpheusSynchronousBackupProviderService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/backup/MorpheusSynchronousBackupProviderService.java
@@ -20,11 +20,29 @@ import com.morpheusdata.core.MorpheusSynchronousDataService;
 import com.morpheusdata.model.BackupProvider;
 import com.morpheusdata.model.BackupProviderType;
 
+/**
+ * Synchronous context methods for interacting with {@link BackupProvider} in Morpheus. A backup provider is the primary
+ * integration point between morpheus and an external service.
+ * @since 1.3.1
+ * @author Chris Johnson
+ */
 public interface MorpheusSynchronousBackupProviderService extends MorpheusSynchronousDataService<BackupProvider, BackupProvider> {
+
 	/**
-	 * Returns the MorpheusBackupProviderTypeContext used for performing updates/queries on {@link BackupProviderType} related assets
-	 * within Morpheus.
+	 * Returns the MorpheusBackupProviderTypeContext used for performing updates/queries on {@link BackupProviderType}
+	 * related assets within Morpheus.
 	 * @return An instance of the BackupProviderTypeContext to be used for calls by various backup providers
 	 */
 	MorpheusSynchronousBackupProviderTypeService getType();
+
+	/**
+	 * Save a status update to a backup provider. When the status is updated to "error" or "offline" an alarm will be
+	 * created with the message provided. When the status is updated to "online" any alarms on the provider will be
+	 * cleared.
+	 * @param backupProvider backup provider to update
+	 * @param status status to be set on the backup provider
+	 * @param message additional context for the current status. Useful in the case of adding details for an error or warning status.
+	 * @return success
+	 */
+	Boolean updateStatus(BackupProvider backupProvider, String status, String message);
 }


### PR DESCRIPTION
### Issues
- [MORPH-4891](https://hpe.atlassian.net/browse/MORPH-4891) - Remove veeam embeeded

### Description
This adds a copy of `updateStatus` to `MorpheusSynchronousBackupProviderService`. Its async counterpart already exists.