### PR TITLE
MORPH-6228: Add AuditLog plugin DataService

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusAdminService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusAdminService.java
@@ -36,4 +36,11 @@ public interface MorpheusAdminService {
 	 * @return an instance of the implementation of the {@link MorpheusApplianceService}
 	 */
 	MorpheusApplianceService getAppliance();
+
+	/**
+	 * Returns the AuditLog Service for inserting and querying audit log entries asynchronously (reactive).
+	 * Plugins may insert entries but cannot modify or delete existing ones.
+	 * @return an instance of the implementation of the {@link MorpheusAuditLogService}
+	 */
+	MorpheusAuditLogService getAuditLog();
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusAuditLogService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusAuditLogService.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2025 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.admin;
+
+import com.morpheusdata.core.MorpheusDataService;
+import com.morpheusdata.core.MorpheusIdentityService;
+import com.morpheusdata.model.AuditLog;
+import com.morpheusdata.model.projection.AuditLogIdentityProjection;
+import io.reactivex.rxjava3.core.Single;
+
+/**
+ * Provides a plugin-accessible interface for interacting with audit log entries.
+ * Plugins may insert new audit log entries and query existing ones.
+ * <p>
+ * <strong>Note:</strong> Audit log entries cannot be modified or deleted via this service.
+ * The {@link #save} and {@link #remove} operations are intentionally no-ops to preserve
+ * the integrity of the audit trail.
+ * </p>
+ *
+ * <p>Accessible via {@code morpheusContext.async.admin.getAuditLog()}.</p>
+ */
+public interface MorpheusAuditLogService extends MorpheusDataService<AuditLog, AuditLogIdentityProjection>, MorpheusIdentityService<AuditLogIdentityProjection> {
+
+	/**
+	 * Inserts a DEBUG-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to DEBUG)
+	 * @return Single wrapping the saved entry
+	 */
+	Single<AuditLog> logDebug(AuditLog auditLog);
+
+	/**
+	 * Inserts an INFO-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to INFO)
+	 * @return Single wrapping the saved entry
+	 */
+	Single<AuditLog> logInfo(AuditLog auditLog);
+
+	/**
+	 * Inserts a WARN-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to WARN)
+	 * @return Single wrapping the saved entry
+	 */
+	Single<AuditLog> logWarn(AuditLog auditLog);
+
+	/**
+	 * Inserts an ERROR-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to ERROR)
+	 * @return Single wrapping the saved entry
+	 */
+	Single<AuditLog> logError(AuditLog auditLog);
+
+	/**
+	 * Inserts a FATAL-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to FATAL)
+	 * @return Single wrapping the saved entry
+	 */
+	Single<AuditLog> logFatal(AuditLog auditLog);
+
+	/**
+	 * Inserts an audit log entry at the specified level.
+	 * @param level the log level (use {@link AuditLog} level constants: LEVEL_DEBUG, LEVEL_INFO, LEVEL_WARN, LEVEL_ERROR, LEVEL_FATAL)
+	 * @param auditLog the entry to insert
+	 * @return Single wrapping the saved entry
+	 */
+	Single<AuditLog> log(Integer level, AuditLog auditLog);
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/admin/MorpheusSynchronousAdminService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/admin/MorpheusSynchronousAdminService.java
@@ -21,4 +21,6 @@ public interface MorpheusSynchronousAdminService {
 	MorpheusSynchronousUserService getUser();
 
 	MorpheusSynchronousApplianceService getAppliance();
+
+	MorpheusSynchronousAuditLogService getAuditLog();
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/admin/MorpheusSynchronousAuditLogService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/admin/MorpheusSynchronousAuditLogService.java
@@ -1,0 +1,80 @@
+/*
+ *  Copyright 2025 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.synchronous.admin;
+
+import com.morpheusdata.core.MorpheusDataService;
+import com.morpheusdata.core.MorpheusIdentityService;
+import com.morpheusdata.core.MorpheusSynchronousDataService;
+import com.morpheusdata.core.MorpheusSynchronousIdentityService;
+import com.morpheusdata.model.AuditLog;
+import com.morpheusdata.model.projection.AuditLogIdentityProjection;
+
+/**
+ * Provides synchronous plugin-accessible access to audit log entries.
+ * Plugins may insert new entries and query existing ones.
+ * <p>
+ * <strong>Note:</strong> Audit log entries cannot be modified or deleted to preserve
+ * the integrity of the audit trail.
+ * </p>
+ *
+ * <p>Accessible via {@code morpheusContext.services.admin.getAuditLog()}.</p>
+ */
+public interface MorpheusSynchronousAuditLogService extends MorpheusSynchronousDataService<AuditLog, AuditLogIdentityProjection>, MorpheusSynchronousIdentityService<AuditLogIdentityProjection> {
+
+	/**
+	 * Inserts a DEBUG-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to DEBUG)
+	 * @return the saved entry
+	 */
+	AuditLog logDebug(AuditLog auditLog);
+
+	/**
+	 * Inserts an INFO-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to INFO)
+	 * @return the saved entry
+	 */
+	AuditLog logInfo(AuditLog auditLog);
+
+	/**
+	 * Inserts a WARN-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to WARN)
+	 * @return the saved entry
+	 */
+	AuditLog logWarn(AuditLog auditLog);
+
+	/**
+	 * Inserts an ERROR-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to ERROR)
+	 * @return the saved entry
+	 */
+	AuditLog logError(AuditLog auditLog);
+
+	/**
+	 * Inserts a FATAL-level audit log entry.
+	 * @param auditLog the entry to insert (level will be set to FATAL)
+	 * @return the saved entry
+	 */
+	AuditLog logFatal(AuditLog auditLog);
+
+	/**
+	 * Inserts an audit log entry at the specified level.
+	 * @param level the log level (use {@link AuditLog} level constants: LEVEL_DEBUG, LEVEL_INFO, LEVEL_WARN, LEVEL_ERROR, LEVEL_FATAL)
+	 * @param auditLog the entry to insert
+	 * @return the saved entry
+	 */
+	AuditLog log(Integer level, AuditLog auditLog);
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/AuditLog.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/AuditLog.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright 2025 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model;
+
+import com.morpheusdata.model.projection.AuditLogIdentityProjection;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.morpheusdata.model.serializers.ModelAsIdOnlySerializer;
+
+/**
+ * Represents an audit log entry recording a significant action in Morpheus.
+ * AuditLog entries can be inserted by plugins but cannot be modified or deleted
+ * to preserve the integrity of the audit trail.
+ */
+public class AuditLog extends AuditLogIdentityProjection {
+
+	public static final int LEVEL_DEBUG = 0;
+	public static final int LEVEL_INFO = 1;
+	public static final int LEVEL_WARN = 2;
+	public static final int LEVEL_ERROR = 3;
+	public static final int LEVEL_FATAL = 4;
+
+	@JsonSerialize(using = ModelAsIdOnlySerializer.class)
+	protected Account account;
+	@JsonSerialize(using = ModelAsIdOnlySerializer.class)
+	protected User user;
+	@JsonSerialize(using = ModelAsIdOnlySerializer.class)
+	protected User actualUser;
+	protected String description;
+	protected String logSignature;
+
+	public Account getAccount() {
+		return account;
+	}
+
+	public void setAccount(Account account) {
+		markDirty("account", account);
+		this.account = account;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public void setUser(User user) {
+		markDirty("user", user);
+		this.user = user;
+	}
+
+	public User getActualUser() {
+		return actualUser;
+	}
+
+	public void setActualUser(User actualUser) {
+		markDirty("actualUser", actualUser);
+		this.actualUser = actualUser;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		markDirty("description", description);
+		this.description = description;
+	}
+
+	public String getLogSignature() {
+		return logSignature;
+	}
+
+	public void setLogSignature(String logSignature) {
+		markDirty("logSignature", logSignature);
+		this.logSignature = logSignature;
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/AuditLogIdentityProjection.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/AuditLogIdentityProjection.java
@@ -1,0 +1,76 @@
+/*
+ *  Copyright 2025 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model.projection;
+
+import java.util.Date;
+
+/**
+ * Provides a subset of properties from the {@link com.morpheusdata.model.AuditLog}
+ * for comparison with less bandwidth usage and memory footprint. This is a DTO Projection object.
+ */
+public class AuditLogIdentityProjection extends MorpheusIdentityModel {
+	protected String eventType;
+	protected Integer level;
+	protected String objectClass;
+	protected String objectId;
+	protected Date dateCreated;
+
+	public String getEventType() {
+		return eventType;
+	}
+
+	public void setEventType(String eventType) {
+		this.eventType = eventType;
+		markDirty("eventType", eventType, this.eventType);
+	}
+
+	public Integer getLevel() {
+		return level;
+	}
+
+	public void setLevel(Integer level) {
+		this.level = level;
+		markDirty("level", level, this.level);
+	}
+
+	public String getObjectClass() {
+		return objectClass;
+	}
+
+	public void setObjectClass(String objectClass) {
+		this.objectClass = objectClass;
+		markDirty("objectClass", objectClass, this.objectClass);
+	}
+
+	public String getObjectId() {
+		return objectId;
+	}
+
+	public void setObjectId(String objectId) {
+		this.objectId = objectId;
+		markDirty("objectId", objectId, this.objectId);
+	}
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date dateCreated) {
+		this.dateCreated = dateCreated;
+		markDirty("dateCreated", dateCreated, this.dateCreated);
+	}
+}


### PR DESCRIPTION
## MORPH-6228 — Create AuditLog Plugin Data Service

Implements plugin-accessible AuditLog DataService allowing plugins to insert and query audit log entries.

### Changes
- **New**: `AuditLogIdentityProjection` and `AuditLog` model (with level constants DEBUG/INFO/WARN/ERROR/FATAL)
- **New**: `MorpheusAuditLogService` async interface — extends `MorpheusDataService` + `MorpheusIdentityService`; convenience methods `logDebug/logInfo/logWarn/logError/logFatal/log(Integer, AuditLog)`
- **New**: `MorpheusSynchronousAuditLogService` sync interface
- **Modified**: `MorpheusAdminService` and `MorpheusSynchronousAdminService` — added `getAuditLog()`

### Notes
- `save()`/`remove()` are intentionally absent — audit log entries are immutable by design
- Pairs with morpheus-ui PR for the impl service