### PR TITLE
MORPH-8242: Add pool lifecycle and option type methods to IPAMProvider

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/IPAMProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/IPAMProvider.java
@@ -129,11 +129,60 @@ public interface IPAMProvider extends PluginProvider {
 	List<OptionType> getIntegrationOptionTypes();
 
 	/**
+	 * Provide custom configuration options when creating or editing a {@link NetworkPool} for
+	 * one of this provider's registered {@link NetworkPoolType} records.
+	 * @return a List of OptionType
+	 * @since 1.3.2
+	 */
+	default List<OptionType> getNetworkPoolOptionTypes() {
+		return List.of();
+	}
+
+	/**
 	 * Returns the IPAM Integration logo for display when a user needs to view or add this integration
 	 * @since 0.12.3
 	 * @return Icon representation of assets stored in the src/assets of the project.
 	 */
 	Icon getIcon();
+
+	/**
+	 * Called when a {@link NetworkPool} is created in Morpheus. Override to perform any corresponding
+	 * operations on the external IPAM system (e.g. creating a subnet).
+	 * @param poolServer The Integration Object contains all the saved information regarding configuration of the IPAM Provider.
+	 * @param networkPool the NetworkPool that was created.
+	 * @param opts any custom payload submission options may exist here
+	 * @return a ServiceResponse containing the success state of the operation
+	 * @since 1.3.2
+	 */
+	default ServiceResponse createNetworkPool(NetworkPoolServer poolServer, NetworkPool networkPool, Map opts) {
+		return ServiceResponse.success();
+	}
+
+	/**
+	 * Called when a {@link NetworkPool} is updated in Morpheus. Override to perform any corresponding
+	 * operations on the external IPAM system.
+	 * @param poolServer The Integration Object contains all the saved information regarding configuration of the IPAM Provider.
+	 * @param networkPool the NetworkPool that was updated.
+	 * @param opts any custom payload submission options may exist here
+	 * @return a ServiceResponse containing the success state of the operation
+	 * @since 1.3.2
+	 */
+	default ServiceResponse updateNetworkPool(NetworkPoolServer poolServer, NetworkPool networkPool, Map opts) {
+		return ServiceResponse.success();
+	}
+
+	/**
+	 * Called when a {@link NetworkPool} is deleted from Morpheus. Override to perform any corresponding
+	 * cleanup on the external IPAM system.
+	 * @param poolServer The Integration Object contains all the saved information regarding configuration of the IPAM Provider.
+	 * @param networkPool the NetworkPool that was deleted.
+	 * @param opts any custom payload submission options may exist here
+	 * @return a ServiceResponse containing the success state of the operation
+	 * @since 1.3.2
+	 */
+	default ServiceResponse deleteNetworkPool(NetworkPoolServer poolServer, NetworkPool networkPool, Map opts) {
+		return ServiceResponse.success();
+	}
 
 	/**
 	 * Flags if this IPAMProvider can be created by the user. Some IPAMProviders are system injected


### PR DESCRIPTION
## Summary

- Adds `createNetworkPool`, `updateNetworkPool`, `deleteNetworkPool` default methods to `IPAMProvider` so plugins can react when a user creates/updates/deletes a `NetworkPool` through the Morpheus UI.
- Adds `getNetworkPoolOptionTypes()` default method so plugins can provide custom option types (e.g. a pool server selector) for pool create/edit forms.

All methods are `default` with no-op implementations — fully backward compatible.

## Related PRs

- **morpheus-ui**: HPE-EMU/morpheus-ui — PR pending
- **morpheus-omega-test-plugin**: HewlettPackard/morpheus-omega-test-plugin — PR pending

Links will be updated once all PRs are created.