### PR TITLE
Move network pool option types onto NetworkPoolType

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/IPAMProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/IPAMProvider.java
@@ -129,16 +129,6 @@ public interface IPAMProvider extends PluginProvider {
 	List<OptionType> getIntegrationOptionTypes();
 
 	/**
-	 * Provide custom configuration options when creating or editing a {@link NetworkPool} for
-	 * one of this provider's registered {@link NetworkPoolType} records.
-	 * @return a List of OptionType
-	 * @since 1.3.2
-	 */
-	default List<OptionType> getNetworkPoolOptionTypes() {
-		return List.of();
-	}
-
-	/**
 	 * Returns the IPAM Integration logo for display when a user needs to view or add this integration
 	 * @since 0.12.3
 	 * @return Icon representation of assets stored in the src/assets of the project.

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/NetworkPoolType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/NetworkPoolType.java
@@ -18,6 +18,9 @@ package com.morpheusdata.model;
 
 import com.morpheusdata.core.providers.IPAMProvider;
 
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * Each implementation of IPAM Typically define a pool type for human readable reference. This enables the user to correctly
  * select the pool of the appropriate type. It is also possible for some {@link IPAMProvider} implementations to provide
@@ -60,6 +63,8 @@ public class NetworkPoolType extends MorpheusModel{
 	protected Boolean loadBalancerCompatible = false;
 
 	protected Boolean floatingIpPool = false;
+
+	protected List<OptionType> optionTypes = new ArrayList<>();
 
 
 	/**
@@ -198,6 +203,15 @@ public class NetworkPoolType extends MorpheusModel{
 	public void setFloatingIpPool(Boolean floatingIpPool) {
 		this.floatingIpPool = floatingIpPool;
 		markDirty("floatingIpPool", floatingIpPool);
+	}
+
+	public List<OptionType> getOptionTypes() {
+		return optionTypes;
+	}
+
+	public void setOptionTypes(List<OptionType> optionTypes) {
+		this.optionTypes = optionTypes;
+		markDirty("optionTypes", optionTypes);
 	}
 
 }


### PR DESCRIPTION
Add optionTypes to the plugin API NetworkPoolType model so pool create/edit fields can be defined on each returned pool type directly. Remove the provider-scoped getNetworkPoolOptionTypes() method from IPAMProvider to match the existing per-type optionTypes pattern used by other plugin models.