### PR TITLE
[MORPH-5870] Add categories and a general support bundle provider

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/PluginProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/PluginProvider.java
@@ -198,6 +198,30 @@ public interface PluginProvider {
 	 * @author Mike Carlin
 	 */
 	public interface SupportBundleFacet<T> {
+
+		/**
+		 * Returns the human-readable display name for this support bundle content type as shown in
+		 * the CLI, API, and UI pickers. Defaults to the provider's own {@link PluginProvider#getName()}
+		 * if not overridden, but implementations should override this to give the bundle entry a more
+		 * descriptive label (e.g. "VMware vSphere Logs" rather than "VMware vSphere").
+		 *
+		 * @return the display name; must not be null
+		 */
+		default String getSupportBundleName() {
+			return ((PluginProvider) this).getName();
+		}
+
+		/**
+		 * Returns an optional description of what this content type contributes to the support bundle
+		 * (e.g. "Includes vCenter event logs, cluster configuration, and host diagnostics"). Shown in
+		 * tooltips and detail views in the CLI and UI. Returns {@code null} by default.
+		 *
+		 * @return the description string, or null if none
+		 */
+		default String getSupportBundleDescription() {
+			return null;
+		}
+
 		/**
 		 * Generate support bundle contents for the target device. This is useful for collecting logs,
 		 * configuration files, and other relevant information for troubleshooting.
@@ -209,5 +233,6 @@ public interface PluginProvider {
 		default ServiceResponse<GenerateSupportBundleContentsResponse> generateSupportBundleContents(T target, GenerateSupportBundleContentsRequest request) {
 			return ServiceResponse.success(new GenerateSupportBundleContentsResponse());
 		}
+
 	}
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/SupportBundleContentsProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/SupportBundleContentsProvider.java
@@ -26,13 +26,6 @@ import com.morpheusdata.response.ServiceResponse;
  * to a support bundle — for example, appliance logs, health snapshots, or any other diagnostic
  * data that is not tied to a specific cloud, cluster, or other resource type.
  *
- * <p>When registered, Morpheus creates a {@code SupportBundleContentType} row (standalone kind,
- * {@code refType=null}, {@code refId=null}) keyed by {@link #getCode()} with the category from
- * {@link #getCategory()}, name from {@link #getSupportBundleName()}, and description from
- * {@link #getSupportBundleDescription()}. The row's {@code serviceBean} is set to
- * {@code "pluginSupportBundleContentsService"}, the single Morpheus-internal dispatcher that
- * routes generate requests to the correct registered provider by code.
- *
  * <p>To include this provider's content in a bundle, the API caller includes a content entry
  * with {@code "type": "&lt;your-code&gt;"} in the generate request.
  *

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/SupportBundleContentsProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/SupportBundleContentsProvider.java
@@ -1,0 +1,89 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.providers;
+
+import com.morpheusdata.model.GenerateSupportBundleContentsRequest;
+import com.morpheusdata.model.GenerateSupportBundleContentsResponse;
+import com.morpheusdata.model.SupportBundleCategory;
+import com.morpheusdata.response.ServiceResponse;
+
+/**
+ * A standalone support bundle content provider. Implement this interface to add custom content
+ * to a support bundle — for example, appliance logs, health snapshots, or any other diagnostic
+ * data that is not tied to a specific cloud, cluster, or other resource type.
+ *
+ * <p>When registered, Morpheus creates a {@code SupportBundleContentType} row (standalone kind,
+ * {@code refType=null}, {@code refId=null}) keyed by {@link #getCode()} with the category from
+ * {@link #getCategory()}, name from {@link #getSupportBundleName()}, and description from
+ * {@link #getSupportBundleDescription()}. The row's {@code serviceBean} is set to
+ * {@code "pluginSupportBundleContentsService"}, the single Morpheus-internal dispatcher that
+ * routes generate requests to the correct registered provider by code.
+ *
+ * <p>To include this provider's content in a bundle, the API caller includes a content entry
+ * with {@code "type": "&lt;your-code&gt;"} in the generate request.
+ *
+ * @since 1.4.0
+ * @author Mike Carlin
+ */
+public interface SupportBundleContentsProvider extends PluginProvider {
+
+	/**
+	 * Returns the UI grouping category for this content type. Used by
+	 * {@code GET /api/support-bundles/content-types} to group entries in the picker and as the
+	 * lowercased directory prefix inside the generated bundle archive.
+	 *
+	 * @return the category; must not be null
+	 */
+	SupportBundleCategory getCategory();
+
+	/**
+	 * Returns the human-readable display name for this support bundle content type. Shown as
+	 * the component label in the bundle picker and in CLI/API output. Defaults to
+	 * {@link PluginProvider#getName()} so simple providers need not override it.
+	 *
+	 * @return the display name; must not be null
+	 */
+	default String getSupportBundleName() {
+		return getName();
+	}
+
+	/**
+	 * Returns an optional human-readable description of what this content type contributes to
+	 * the support bundle. Shown in tooltips and detail views in the CLI and UI.
+	 *
+	 * @return the description string, or null if none
+	 */
+	default String getSupportBundleDescription() {
+		return null;
+	}
+
+	/**
+	 * Generate the support bundle contents for this provider. Morpheus calls this when a bundle
+	 * generate request includes a component whose {@code type} matches {@link #getCode()}.
+	 *
+	 * <p>Write any files into {@code request.contentsDir}. Augment {@code request.resourceInfo}
+	 * with any key/value pairs that should appear in the generated {@code info.json} for this
+	 * component.
+	 *
+	 * @param request request containing the bundle record, output directory, and resource info map
+	 * @return a ServiceResponse indicating success or failure
+	 */
+	default ServiceResponse<GenerateSupportBundleContentsResponse> generateSupportBundleContents(
+			GenerateSupportBundleContentsRequest request) {
+		return ServiceResponse.success(new GenerateSupportBundleContentsResponse());
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SupportBundleCategory.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SupportBundleCategory.java
@@ -19,50 +19,45 @@ package com.morpheusdata.model;
 /**
  * Fixed set of UI grouping categories for support bundle content types.
  *
- * <p>Plugin authors must choose one of these values when implementing
- * {@link com.morpheusdata.core.providers.SupportBundleContentsProvider#getCategory()}.
- * This prevents arbitrary category strings from appearing in the Morpheus UI.
- *
  * @since 1.4.0
  * @author Mike Carlin
  */
 public enum SupportBundleCategory {
+	/** Appliance-level content (logs, version info, health snapshots, etc.). */
+	APPLIANCE("Appliance"),
 
-    /** Appliance-level content (logs, version info, health snapshots, etc.). */
-    APPLIANCE("Appliance"),
+	/** Cloud integration content. */
+	CLOUDS("Clouds"),
 
-    /** Cloud integration content. */
-    CLOUDS("Clouds"),
+	/** Bare-metal / compute server content. */
+	SERVERS("Servers"),
 
-    /** Bare-metal / compute server content. */
-    SERVERS("Servers"),
+	/** Cluster content. */
+	CLUSTERS("Clusters"),
 
-    /** Cluster content. */
-    CLUSTERS("Clusters"),
+	/** Network integration content. */
+	NETWORKING("Networking"),
 
-    /** Network integration content. */
-    NETWORKING("Networking"),
+	/** Storage integration content. */
+	STORAGE("Storage"),
 
-    /** Storage integration content. */
-    STORAGE("Storage"),
+	/** System integration content. */
+	SYSTEMS("Systems");
 
-    /** System integration content. */
-    SYSTEMS("Systems");
+	/** Human-readable display label (used in the Morpheus UI picker and API responses). */
+	public final String label;
 
-    /** Human-readable display label (used in the Morpheus UI picker and API responses). */
-    public final String label;
+	SupportBundleCategory(String label) {
+		this.label = label;
+	}
 
-    SupportBundleCategory(String label) {
-        this.label = label;
-    }
-
-    /**
-     * Returns the display label for this category (e.g. {@code "Clouds"}).
-     *
-     * @return the display label; never null
-     */
-    @Override
-    public String toString() {
-        return label;
-    }
+	/**
+	 * Returns the display label for this category (e.g. {@code "Clouds"}).
+	 *
+	 * @return the display label; never null
+	 */
+	@Override
+	public String toString() {
+		return label;
+	}
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SupportBundleCategory.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SupportBundleCategory.java
@@ -1,0 +1,68 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model;
+
+/**
+ * Fixed set of UI grouping categories for support bundle content types.
+ *
+ * <p>Plugin authors must choose one of these values when implementing
+ * {@link com.morpheusdata.core.providers.SupportBundleContentsProvider#getCategory()}.
+ * This prevents arbitrary category strings from appearing in the Morpheus UI.
+ *
+ * @since 1.4.0
+ * @author Mike Carlin
+ */
+public enum SupportBundleCategory {
+
+    /** Appliance-level content (logs, version info, health snapshots, etc.). */
+    APPLIANCE("Appliance"),
+
+    /** Cloud integration content. */
+    CLOUDS("Clouds"),
+
+    /** Bare-metal / compute server content. */
+    SERVERS("Servers"),
+
+    /** Cluster content. */
+    CLUSTERS("Clusters"),
+
+    /** Network integration content. */
+    NETWORKING("Networking"),
+
+    /** Storage integration content. */
+    STORAGE("Storage"),
+
+    /** System integration content. */
+    SYSTEMS("Systems");
+
+    /** Human-readable display label (used in the Morpheus UI picker and API responses). */
+    public final String label;
+
+    SupportBundleCategory(String label) {
+        this.label = label;
+    }
+
+    /**
+     * Returns the display label for this category (e.g. {@code "Clouds"}).
+     *
+     * @return the display label; never null
+     */
+    @Override
+    public String toString() {
+        return label;
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `SupportBundleContentsProvider` interface for plugins to contribute support bundle content types
- Adds `SupportBundleCategory` model with predefined categories (`SYSTEM`, `NETWORK`, `APPLIANCE`)
- Wires `SupportBundleContentsProvider` into `PluginProvider` as a supported provider type

## Related

- Jira: https://jira.morpheusdata.com/browse/MORPH-5870
- morpheus-ui PR: https://github.com/HPE-EMU/morpheus-ui/pull/3412