### PR TITLE
MORPH-7750 add typed hypervisor console contract

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ProvisionProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ProvisionProvider.java
@@ -655,10 +655,92 @@ public interface ProvisionProvider extends PluginProvider {
 	}
 
 	/**
+	 * Provides a typed hypervisor console contract for browser-based VM consoles.
+	 *
+	 * Implement this facet for new development. The returned
+	 * {@link HypervisorConsoleConnection#getProtocols()} value controls WebSocket sub-protocol handling:
+	 *
+	 * <ul>
+	 *     <li>{@code null}: no override specified, preserve Morpheus defaults</li>
+	 *     <li>empty list: send no {@code Sec-WebSocket-Protocol} header</li>
+	 *     <li>non-empty list: send the provided values in order</li>
+	 * </ul>
+	 *
+	 * @author Dustin DeYoung
+	 * @since 1.3.4
+	 */
+	public interface HypervisorConsoleFacetV2 {
+
+		/**
+		 * Builds the connection details required to connect to the target server using xvpVnc.
+		 * @since 1.3.4
+		 * @param server server to connect to
+		 * @return Connection details for an xvpVnc console connection to the server
+		 */
+		default ServiceResponse<HypervisorConsoleConnection> getXvpVNCConsoleConnection(ComputeServer server) {
+			return null;
+		}
+
+		/**
+		 * Builds the connection details required to connect to the target server using noVNC.
+		 * @since 1.3.4
+		 * @param server server to connect to
+		 * @return Connection details for a noVNC console connection to the server
+		 */
+		default ServiceResponse<HypervisorConsoleConnection> getNoVNCConsoleConnection(ComputeServer server) {
+			return null;
+		}
+
+		/**
+		 * Builds the connection details required to connect to the target server using WMKS.
+		 * @since 1.3.4
+		 * @param server server to connect to
+		 * @return Connection details for a WMKS console connection to the server
+		 */
+		default ServiceResponse<HypervisorConsoleConnection> getWMKSConsoleConnection(ComputeServer server) {
+			return null;
+		}
+
+		/**
+		 * Method called before using the console host to ensure it is accurate.
+		 * @since 1.3.4
+		 * @param server server to connect to
+		 * @return Success or failure
+		 */
+		default ServiceResponse updateServerHost(ComputeServer server){
+			return null;
+		}
+
+		/**
+		 * Method called before making a hypervisor console connection to a server to ensure that the server settings are correct.
+		 * @since 1.3.4
+		 * @param server server to connect to
+		 * @return Success or failure
+		 */
+		default ServiceResponse enableConsoleAccess(ComputeServer server){
+			return null;
+		}
+	}
+
+	/**
 	 * Provides methods for interacting with provisioned vms through a hypervisor console
+	 *
+	 * Console connection data is returned as a generic map for backward compatibility.
+	 * Legacy implementations may optionally include a {@code protocols} key to override
+	 * WebSocket sub-protocol handling:
+	 *
+	 * <ul>
+	 *     <li>omit {@code protocols}: preserve Morpheus defaults</li>
+	 *     <li>{@code protocols: []}: send no {@code Sec-WebSocket-Protocol} header</li>
+	 *     <li>{@code protocols: ['plain.kubevirt.io']}: send the provided values in order</li>
+	 * </ul>
+	 *
 	 * @author Alex Clement
 	 * @since 0.15.3
+	 * @deprecated Since 1.3.4. Use {@link HypervisorConsoleFacetV2}. This legacy map-based
+	 * console contract will be removed in a future release.
 	 */
+	@Deprecated(since = "1.3.4", forRemoval = false)
 	public interface HypervisorConsoleFacet {
 
 		/**

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/HypervisorConsoleConnection.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/HypervisorConsoleConnection.java
@@ -1,0 +1,136 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model;
+
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Describes the connection details needed to establish a hypervisor console session.
+ *
+ * The {@code protocols} property controls the {@code Sec-WebSocket-Protocol} request header
+ * when browser-based console access is proxied through Morpheus:
+ *
+ * <ul>
+ *     <li>{@code null}: no override specified. Morpheus will preserve its default behavior.</li>
+ *     <li>empty list: explicitly send no {@code Sec-WebSocket-Protocol} header.</li>
+ *     <li>non-empty list: send the provided values in order.</li>
+ * </ul>
+ *
+ * @since 1.3.4
+ */
+public class HypervisorConsoleConnection {
+	protected String url;
+	protected String token;
+	protected String host;
+	protected Integer port;
+	protected Map<String,String> headers;
+	protected List<String> protocols;
+	protected String keyExtension;
+	protected String keymap;
+	protected Boolean fakePasswordVNC;
+	protected String vmxHandshakePath;
+	protected String httpVersion;
+
+	public String getUrl() {
+		return url;
+	}
+
+	public void setUrl(String url) {
+		this.url = url;
+	}
+
+	public String getToken() {
+		return token;
+	}
+
+	public void setToken(String token) {
+		this.token = token;
+	}
+
+	public String getHost() {
+		return host;
+	}
+
+	public void setHost(String host) {
+		this.host = host;
+	}
+
+	public Integer getPort() {
+		return port;
+	}
+
+	public void setPort(Integer port) {
+		this.port = port;
+	}
+
+	public Map<String, String> getHeaders() {
+		return headers;
+	}
+
+	public void setHeaders(Map<String, String> headers) {
+		this.headers = headers;
+	}
+
+	public List<String> getProtocols() {
+		return protocols;
+	}
+
+	public void setProtocols(List<String> protocols) {
+		this.protocols = protocols;
+	}
+
+	public String getKeyExtension() {
+		return keyExtension;
+	}
+
+	public void setKeyExtension(String keyExtension) {
+		this.keyExtension = keyExtension;
+	}
+
+	public String getKeymap() {
+		return keymap;
+	}
+
+	public void setKeymap(String keymap) {
+		this.keymap = keymap;
+	}
+
+	public Boolean getFakePasswordVNC() {
+		return fakePasswordVNC;
+	}
+
+	public void setFakePasswordVNC(Boolean fakePasswordVNC) {
+		this.fakePasswordVNC = fakePasswordVNC;
+	}
+
+	public String getVmxHandshakePath() {
+		return vmxHandshakePath;
+	}
+
+	public void setVmxHandshakePath(String vmxHandshakePath) {
+		this.vmxHandshakePath = vmxHandshakePath;
+	}
+
+	public String getHttpVersion() {
+		return httpVersion;
+	}
+
+	public void setHttpVersion(String httpVersion) {
+		this.httpVersion = httpVersion;
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/HypervisorConsoleConnection.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/HypervisorConsoleConnection.java
@@ -16,6 +16,8 @@
 
 package com.morpheusdata.model;
 
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -38,13 +40,7 @@ public class HypervisorConsoleConnection {
 	protected String token;
 	protected String host;
 	protected Integer port;
-	protected Map<String,String> headers;
 	protected List<String> protocols;
-	protected String keyExtension;
-	protected String keymap;
-	protected Boolean fakePasswordVNC;
-	protected String vmxHandshakePath;
-	protected String httpVersion;
 
 	public String getUrl() {
 		return url;
@@ -78,14 +74,6 @@ public class HypervisorConsoleConnection {
 		this.port = port;
 	}
 
-	public Map<String, String> getHeaders() {
-		return headers;
-	}
-
-	public void setHeaders(Map<String, String> headers) {
-		this.headers = headers;
-	}
-
 	public List<String> getProtocols() {
 		return protocols;
 	}
@@ -94,43 +82,18 @@ public class HypervisorConsoleConnection {
 		this.protocols = protocols;
 	}
 
-	public String getKeyExtension() {
-		return keyExtension;
-	}
-
-	public void setKeyExtension(String keyExtension) {
-		this.keyExtension = keyExtension;
-	}
-
-	public String getKeymap() {
-		return keymap;
-	}
-
-	public void setKeymap(String keymap) {
-		this.keymap = keymap;
-	}
-
-	public Boolean getFakePasswordVNC() {
-		return fakePasswordVNC;
-	}
-
-	public void setFakePasswordVNC(Boolean fakePasswordVNC) {
-		this.fakePasswordVNC = fakePasswordVNC;
-	}
-
-	public String getVmxHandshakePath() {
-		return vmxHandshakePath;
-	}
-
-	public void setVmxHandshakePath(String vmxHandshakePath) {
-		this.vmxHandshakePath = vmxHandshakePath;
-	}
-
-	public String getHttpVersion() {
-		return httpVersion;
-	}
-
-	public void setHttpVersion(String httpVersion) {
-		this.httpVersion = httpVersion;
+	public Map<String, Object> toMap() {
+		Map<String, Object> rtn = new LinkedHashMap<>();
+		if(url != null)
+			rtn.put("url", url);
+		if(token != null)
+			rtn.put("token", token);
+		if(host != null)
+			rtn.put("host", host);
+		if(port != null)
+			rtn.put("port", port);
+		if(protocols != null)
+			rtn.put("protocols", new ArrayList<>(protocols));
+		return rtn;
 	}
 }

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/providers/ProvisionProviderHypervisorConsoleFacetSpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/providers/ProvisionProviderHypervisorConsoleFacetSpec.groovy
@@ -28,7 +28,7 @@ class ProvisionProviderHypervisorConsoleFacetSpec extends Specification {
 		response.success
 		response.data.url == 'wss://console.example/vnc'
 		response.data.protocols == ['plain.kubevirt.io']
-		response.data.headers == ['Authorization': 'Bearer token']
+		response.data.toMap() == [url: 'wss://console.example/vnc', protocols: ['plain.kubevirt.io']]
 	}
 
 	static class TestHypervisorConsoleFacetV2Provider implements ProvisionProvider.HypervisorConsoleFacetV2 {
@@ -37,7 +37,6 @@ class ProvisionProviderHypervisorConsoleFacetSpec extends Specification {
 			def connection = new HypervisorConsoleConnection()
 			connection.url = 'wss://console.example/vnc'
 			connection.protocols = ['plain.kubevirt.io']
-			connection.headers = ['Authorization': 'Bearer token']
 			return ServiceResponse.success(connection)
 		}
 	}

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/providers/ProvisionProviderHypervisorConsoleFacetSpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/providers/ProvisionProviderHypervisorConsoleFacetSpec.groovy
@@ -1,0 +1,44 @@
+package com.morpheusdata.core.providers
+
+import com.morpheusdata.model.ComputeServer
+import com.morpheusdata.model.HypervisorConsoleConnection
+import com.morpheusdata.response.ServiceResponse
+import spock.lang.Specification
+
+class ProvisionProviderHypervisorConsoleFacetSpec extends Specification {
+
+	void "legacy hypervisor console facet is deprecated"() {
+		when:
+		def annotation = ProvisionProvider.HypervisorConsoleFacet.getAnnotation(Deprecated)
+
+		then:
+		annotation != null
+		annotation.since() == '1.3.4'
+		!annotation.forRemoval()
+	}
+
+	void "typed hypervisor console facet returns structured connection response"() {
+		given:
+		def provider = new TestHypervisorConsoleFacetV2Provider()
+
+		when:
+		ServiceResponse<HypervisorConsoleConnection> response = provider.getNoVNCConsoleConnection(new ComputeServer())
+
+		then:
+		response.success
+		response.data.url == 'wss://console.example/vnc'
+		response.data.protocols == ['plain.kubevirt.io']
+		response.data.headers == ['Authorization': 'Bearer token']
+	}
+
+	static class TestHypervisorConsoleFacetV2Provider implements ProvisionProvider.HypervisorConsoleFacetV2 {
+		@Override
+		ServiceResponse<HypervisorConsoleConnection> getNoVNCConsoleConnection(ComputeServer server) {
+			def connection = new HypervisorConsoleConnection()
+			connection.url = 'wss://console.example/vnc'
+			connection.protocols = ['plain.kubevirt.io']
+			connection.headers = ['Authorization': 'Bearer token']
+			return ServiceResponse.success(connection)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- add a typed `HypervisorConsoleFacetV2` and `HypervisorConsoleConnection` DTO for hypervisor console integrations
- deprecate the legacy map-based `HypervisorConsoleFacet` without breaking existing plugins
- document the legacy `protocols` override contract so older plugins can opt in before migrating

## Testing
- `./gradlew --no-daemon :morpheus-plugin-api:test`