### PR TITLE
PCCP-10342: Add SystemCatalogItemUpdate model and CatalogItemFacet

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/SystemProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/SystemProvider.java
@@ -1,6 +1,7 @@
 package com.morpheusdata.core.providers;
 
 import com.morpheusdata.model.Icon;
+import com.morpheusdata.model.SystemCatalogItemUpdate;
 import com.morpheusdata.model.system.*;
 import com.morpheusdata.model.system.System;
 import com.morpheusdata.response.ServiceResponse;
@@ -110,4 +111,25 @@ public interface SystemProvider extends PluginProvider {
 	 * @return
 	 */
 	default ServiceResponse updateSystemComponent(System system, SystemRequest systemRequest, SystemComponentType componentType) { return ServiceResponse.success(); }
+
+	/**
+	 * Applying this facet to a {@link SystemProvider} registers it as a consumer of Central Services
+	 * catalog item updates. Morpheus polls the CS catalog for changes (via hash comparison) and calls
+	 * {@link #onCatalogItemUpdate} for each changed item, allowing the system plugin to process the
+	 * new catalog payload as needed.
+	 *
+	 * @since 1.4.x
+	 */
+	interface CatalogItemFacet {
+
+		/**
+		 * Called when a CS catalog item has changed (new hash detected).
+		 * The system plugin is responsible for determining how to handle the updated payload
+		 * (e.g. downloading packages, updating configuration, triggering workflows).
+		 *
+		 * @param item the catalog item update containing the name, code, hash, payload, and optional version
+		 * @return ServiceResponse indicating success or failure of processing the update
+		 */
+		ServiceResponse onCatalogItemUpdate(SystemCatalogItemUpdate item);
+	}
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SystemCatalogItemUpdate.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/SystemCatalogItemUpdate.java
@@ -1,0 +1,103 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model;
+
+/**
+ * Represents a catalog item update received from Central Services.
+ * Passed to {@link com.morpheusdata.core.providers.SystemProvider.CatalogItemFacet} implementations
+ * when a change is detected in the CS catalog (via hash comparison).
+ *
+ * @author Morpheus Development Team
+ * @since 1.4.x
+ */
+public class SystemCatalogItemUpdate {
+
+	/**
+	 * Human-readable name of the catalog item.
+	 */
+	private String name;
+
+	/**
+	 * Unique code identifying the catalog item.
+	 */
+	private String code;
+
+	/**
+	 * Hash of the catalog item payload, used for change detection.
+	 */
+	private String hash;
+
+	/**
+	 * The full catalog item payload as received from Central Services.
+	 */
+	private String payload;
+
+	/**
+	 * Optional version string for the catalog item.
+	 */
+	private String version;
+
+	public SystemCatalogItemUpdate() {}
+
+	public SystemCatalogItemUpdate(String name, String code, String hash, String payload, String version) {
+		this.name = name;
+		this.code = code;
+		this.hash = hash;
+		this.payload = payload;
+		this.version = version;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getCode() {
+		return code;
+	}
+
+	public void setCode(String code) {
+		this.code = code;
+	}
+
+	public String getHash() {
+		return hash;
+	}
+
+	public void setHash(String hash) {
+		this.hash = hash;
+	}
+
+	public String getPayload() {
+		return payload;
+	}
+
+	public void setPayload(String payload) {
+		this.payload = payload;
+	}
+
+	public String getVersion() {
+		return version;
+	}
+
+	public void setVersion(String version) {
+		this.version = version;
+	}
+}


### PR DESCRIPTION
## Summary
Adds the plugin API types needed for system plugins to receive CS catalog updates.

## Changes
- **`SystemCatalogItemUpdate`**: New model passed to facet providers (fields: `name`, `code`, `hash`, `payload`, `version`)
- **`SystemProvider.CatalogItemFacet`**: New inner interface on `SystemProvider` with `onCatalogItemUpdate(SystemCatalogItemUpdate item)`

## Companion PR
morpheus-ui implementation: https://github.com/HPE-EMU/morpheus-ui/pull/3595