### PR TITLE
MORPH-10026: Add UpdateDefinition DataService

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusAsyncServices.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusAsyncServices.java
@@ -41,6 +41,7 @@ import com.morpheusdata.core.providers.TaskProvider;
 import com.morpheusdata.core.provisioning.MorpheusProvisionService;
 import com.morpheusdata.model.BackupProvider;
 import com.morpheusdata.core.admin.MorpheusAdminService;
+import com.morpheusdata.core.MorpheusUpdateDefinitionService;
 
 public interface MorpheusAsyncServices {
 	/**
@@ -578,4 +579,10 @@ public interface MorpheusAsyncServices {
 	 * @return an instance of the MorpheusLlmService
 	 */
 	MorpheusLlmService getLlm();
+
+	/**
+	 * Returns the {@link MorpheusUpdateDefinitionService} for async CRUD access to {@link com.morpheusdata.model.UpdateDefinition} objects.
+	 * @return an instance of {@link MorpheusUpdateDefinitionService}
+	 */
+	MorpheusUpdateDefinitionService getUpdateDefinition();
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusServices.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusServices.java
@@ -49,6 +49,7 @@ import com.morpheusdata.core.providers.TaskProvider;
 import com.morpheusdata.core.synchronous.provisioning.MorpheusSynchronousProvisionService;
 import com.morpheusdata.core.web.MorpheusWebRequestService;
 import com.morpheusdata.core.localization.MorpheusLocalizationService;
+import com.morpheusdata.core.synchronous.MorpheusSynchronousUpdateDefinitionService;
 import com.morpheusdata.model.BackupProvider;
 
 public interface MorpheusServices {
@@ -563,4 +564,10 @@ public interface MorpheusServices {
 	MorpheusSynchronousProcessService getProcess();
 
 	MorpheusSynchronousAffinityGroupService getAffinityGroup();
+
+	/**
+	 * Returns the {@link MorpheusSynchronousUpdateDefinitionService} for synchronous CRUD access to {@link com.morpheusdata.model.UpdateDefinition} objects.
+	 * @return an instance of {@link MorpheusSynchronousUpdateDefinitionService}
+	 */
+	MorpheusSynchronousUpdateDefinitionService getUpdateDefinition();
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusUpdateDefinitionService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusUpdateDefinitionService.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core;
+
+import com.morpheusdata.model.UpdateDefinition;
+import com.morpheusdata.model.projection.UpdateIdentityProjection;
+
+/**
+ * Provides async CRUD access to {@link UpdateDefinition} objects within the Morpheus appliance.
+ *
+ * @author alex.clement
+ * @since 1.4.0
+ * @see com.morpheusdata.core.synchronous.MorpheusSynchronousUpdateDefinitionService
+ */
+public interface MorpheusUpdateDefinitionService extends MorpheusDataService<UpdateDefinition, UpdateIdentityProjection>, MorpheusIdentityService<UpdateIdentityProjection> {
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousUpdateDefinitionService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousUpdateDefinitionService.java
@@ -1,0 +1,32 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.synchronous;
+
+import com.morpheusdata.core.MorpheusSynchronousDataService;
+import com.morpheusdata.core.MorpheusUpdateDefinitionService;
+import com.morpheusdata.model.UpdateDefinition;
+import com.morpheusdata.model.projection.UpdateIdentityProjection;
+
+/**
+ * Provides synchronous CRUD access to {@link UpdateDefinition} objects within the Morpheus appliance.
+ *
+ * @author alex.clement
+ * @since 1.4.0
+ * @see MorpheusUpdateDefinitionService
+ */
+public interface MorpheusSynchronousUpdateDefinitionService extends MorpheusSynchronousDataService<UpdateDefinition, UpdateIdentityProjection> {
+}


### PR DESCRIPTION
Adds `MorpheusUpdateDefinitionService` and `MorpheusSynchronousUpdateDefinitionService` interfaces, and wires `getUpdateDefinition()` into `MorpheusAsyncServices` and `MorpheusServices`.