### PR TITLE
MORPH-6233 Add ProcessJobProvider interface and process step API

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusProcessService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusProcessService.java
@@ -18,6 +18,10 @@ package com.morpheusdata.core;
 
 import com.morpheusdata.model.*;
 import com.morpheusdata.model.Process;
+import com.morpheusdata.model.process.InsertProcessStepRequest;
+import com.morpheusdata.model.process.InsertProcessStepResponse;
+import com.morpheusdata.model.process.RunProcessStepRequest;
+import com.morpheusdata.model.process.RunProcessStepResponse;
 import io.reactivex.rxjava3.core.Single;
 
 /**
@@ -191,4 +195,21 @@ public interface MorpheusProcessService extends MorpheusDataService<Process, Pro
 	 * @return Boolean indicating success
 	 */
 	Single<Boolean> endProcess(Process process, String processStatus, String output);
+
+	/**
+	 * Insert a new process step (ProcessEvent) into an existing Process without dispatching it.
+	 * The step is created in a 'queued' state and can be dispatched later via {@link #runProcessStep}.
+	 * @param request The request containing the Process and ProcessEvent to insert
+	 * @return An InsertProcessStepResponse containing the id of the created ProcessEvent
+	 */
+	Single<InsertProcessStepResponse> insertProcessStep(InsertProcessStepRequest request);
+
+	/**
+	 * Dispatch a previously inserted process step for execution via the background job system.
+	 * The ProcessEvent's jobName is used as the dispatch key to route execution to the correct
+	 * ProcessJobProvider or service.
+	 * @param request The request containing the Process and ProcessEvent to dispatch
+	 * @return A RunProcessStepResponse indicating whether the dispatch was successful
+	 */
+	Single<RunProcessStepResponse> runProcessStep(RunProcessStepRequest request);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ProcessJobProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ProcessJobProvider.java
@@ -1,0 +1,119 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.providers;
+
+import com.morpheusdata.model.OptionType;
+import com.morpheusdata.model.process.ProcessJobExecutionRequest;
+import com.morpheusdata.model.process.ProcessJobExecutionResponse;
+import com.morpheusdata.response.ServiceResponse;
+
+import java.util.List;
+
+/**
+ * A {@link PluginProvider} that defines a unit of executable async work for a {@link com.morpheusdata.model.ProcessEvent}.
+ * <p>
+ * The provider runs against a single ProcessEvent — it receives the current step's inputs and returns success or
+ * failure, plus optional {@code nextOpts} that get forwarded to the next step in the chain. The provider defines
+ * what the step does. {@code MorpheusProcessService}, {@code ApplianceJobService}, and {@code PluginProcessJobService}
+ * handle scheduling, dispatch, and progression.
+ * <p>
+ * When the plugin loads, Morpheus syncs the provider's metadata into a {@code ProcessJobType} domain row. The
+ * provider's {@link #getCode()} becomes the identifier across the system: it is the {@code ProcessJobType.code}
+ * and the value stored in {@code ProcessEvent.jobName}.
+ *
+ * @since 1.4.0
+ * @author Sean Ridgley
+ */
+public interface ProcessJobProvider extends PluginProvider {
+
+	/**
+	 * A description of this process job provider. Used when syncing provider metadata into the
+	 * ProcessJobType domain row.
+	 *
+	 * @return human-readable description of what this process job does
+	 */
+	String getDescription();
+
+	/**
+	 * Execute the process step.
+	 *
+	 * @param request contains the processEventId and the current step's merged opts
+	 * @return success with optional {@link ProcessJobExecutionResponse#nextOpts} to forward to the next step,
+	 *         or failure to trigger retry/onFail handling
+	 */
+	ServiceResponse<ProcessJobExecutionResponse> execute(ProcessJobExecutionRequest request);
+
+	/**
+	 * Called when a step fails terminally (retries exhausted or not retryable).
+	 * Use for cleanup of side effects from this step. Exceptions are logged
+	 * but do not change the outcome — the step is already failed.
+	 * Not called on cancel.
+	 *
+	 * @param request the same request that was passed to {@link #execute(ProcessJobExecutionRequest)}
+	 * @return a ServiceResponse (success/failure is logged but does not affect the outcome)
+	 */
+	default ServiceResponse onFail(ProcessJobExecutionRequest request) {
+		return ServiceResponse.success();
+	}
+
+	/**
+	 * Whether this step should be automatically retried on failure.
+	 *
+	 * @return true if retryable, false otherwise. Default is false.
+	 */
+	default Boolean isRetryable() {
+		return false;
+	}
+
+	/**
+	 * The maximum number of automatic retry attempts before the step fails terminally.
+	 *
+	 * @return retry count. Default is 5.
+	 */
+	default Integer getRetryCount() {
+		return 5;
+	}
+
+	/**
+	 * The delay in seconds between automatic retry attempts.
+	 *
+	 * @return delay in seconds. Default is 10.
+	 */
+	default Integer getRetryDelaySeconds() {
+		return 10;
+	}
+
+	/**
+	 * Whether this step can be canceled by a user. Canceling sets a flag on the process event;
+	 * the plugin is responsible for checking the canceled flag during execution.
+	 *
+	 * @return true if cancelable, false otherwise. Default is false.
+	 */
+	default Boolean isCancelable() {
+		return false;
+	}
+
+	/**
+	 * Option types that define configurable inputs for this step. These are rendered in the retry
+	 * dialog so users can modify inputs before manually retrying a failed step.
+	 *
+	 * @return list of OptionType definitions. Default is an empty list.
+	 */
+	default List<OptionType> getOptionTypes() {
+		return List.of();
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousProcessService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousProcessService.java
@@ -7,6 +7,10 @@ import com.morpheusdata.model.ProcessStepType;
 import com.morpheusdata.model.ProcessStepUpdate;
 import com.morpheusdata.model.User;
 import com.morpheusdata.model.Workload;
+import com.morpheusdata.model.process.InsertProcessStepRequest;
+import com.morpheusdata.model.process.InsertProcessStepResponse;
+import com.morpheusdata.model.process.RunProcessStepRequest;
+import com.morpheusdata.model.process.RunProcessStepResponse;
 
 public interface MorpheusSynchronousProcessService extends MorpheusSynchronousDataService<Process, Process> {
 
@@ -107,4 +111,21 @@ public interface MorpheusSynchronousProcessService extends MorpheusSynchronousDa
 	 * @return Boolean indicating success
 	 */
 	Boolean endProcess(Process process, String processStatus, String output);
+
+	/**
+	 * Insert a new process step (ProcessEvent) into an existing Process without dispatching it.
+	 * The step is created in a 'queued' state and can be dispatched later via {@link #runProcessStep}.
+	 * @param request The request containing the Process and ProcessEvent to insert
+	 * @return An InsertProcessStepResponse containing the id of the created ProcessEvent
+	 */
+	InsertProcessStepResponse insertProcessStep(InsertProcessStepRequest request);
+
+	/**
+	 * Dispatch a previously inserted process step for execution via the background job system.
+	 * The ProcessEvent's jobName is used as the dispatch key to route execution to the correct
+	 * ProcessJobProvider or service.
+	 * @param request The request containing the Process and ProcessEvent to dispatch
+	 * @return A RunProcessStepResponse indicating whether the dispatch was successful
+	 */
+	RunProcessStepResponse runProcessStep(RunProcessStepRequest request);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ProcessEvent.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ProcessEvent.java
@@ -28,6 +28,7 @@ public class ProcessEvent {
 	 */
 	public ProcessType type;
 	public ProcessStepType stepType;
+	public String eventTitle;
 	public String jobName;
 	public Map jobConfig;
 
@@ -65,6 +66,14 @@ public class ProcessEvent {
 	 */
 	public void setStepType(ProcessStepType stepType) {
 		this.stepType = stepType;
+	}
+
+	public String getEventTitle() {
+		return eventTitle;
+	}
+
+	public void setEventTitle(String eventTitle) {
+		this.eventTitle = eventTitle;
 	}
 
 	public String getJobName() {

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/InsertProcessStepRequest.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/InsertProcessStepRequest.java
@@ -1,0 +1,64 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model.process;
+
+import com.morpheusdata.model.ProcessEvent;
+
+/**
+ * Request model for {@link com.morpheusdata.core.MorpheusProcessService#insertProcessStep}.
+ * Wraps a {@link com.morpheusdata.model.Process} and a {@link ProcessEvent} to insert as a new step.
+ *
+ * @since 1.4.0
+ * @author Sean Ridgley
+ */
+public class InsertProcessStepRequest {
+
+	/**
+	 * The process to insert the step into.
+	 */
+	public com.morpheusdata.model.Process process;
+
+	/**
+	 * The process event defining the step to insert. Set {@code jobName} to the
+	 * {@link com.morpheusdata.core.providers.ProcessJobProvider#getCode()} and {@code jobConfig}
+	 * with any initial inputs.
+	 */
+	public ProcessEvent processEvent;
+
+	public InsertProcessStepRequest() {}
+
+	public InsertProcessStepRequest(com.morpheusdata.model.Process process, ProcessEvent processEvent) {
+		this.process = process;
+		this.processEvent = processEvent;
+	}
+
+	public com.morpheusdata.model.Process getProcess() {
+		return process;
+	}
+
+	public void setProcess(com.morpheusdata.model.Process process) {
+		this.process = process;
+	}
+
+	public ProcessEvent getProcessEvent() {
+		return processEvent;
+	}
+
+	public void setProcessEvent(ProcessEvent processEvent) {
+		this.processEvent = processEvent;
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/InsertProcessStepResponse.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/InsertProcessStepResponse.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model.process;
+
+/**
+ * Response model returned from {@link com.morpheusdata.core.MorpheusProcessService#insertProcessStep}.
+ *
+ * @since 1.4.0
+ * @author Sean Ridgley
+ */
+public class InsertProcessStepResponse {
+
+	/**
+	 * The ID of the newly created ProcessEvent.
+	 */
+	public Long processEventId;
+
+	public InsertProcessStepResponse() {}
+
+	public InsertProcessStepResponse(Long processEventId) {
+		this.processEventId = processEventId;
+	}
+
+	public Long getProcessEventId() {
+		return processEventId;
+	}
+
+	public void setProcessEventId(Long processEventId) {
+		this.processEventId = processEventId;
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/ProcessJobExecutionRequest.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/ProcessJobExecutionRequest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model.process;
+
+import java.util.Map;
+
+/**
+ * Request model passed to {@link com.morpheusdata.core.providers.ProcessJobProvider#execute(ProcessJobExecutionRequest)}.
+ * Contains the process event ID and the current step's merged options.
+ *
+ * @since 1.4.0
+ * @author Sean Ridgley
+ */
+public class ProcessJobExecutionRequest {
+
+	/**
+	 * The ID of the {@code ProcessEvent} being executed.
+	 */
+	public Long processEventId;
+
+	/**
+	 * The current step's inputs — the event's {@code jobMsgConfig} after any {@code stepInputs} merge.
+	 */
+	public Map<String, Object> opts;
+
+	public ProcessJobExecutionRequest() {}
+
+	public ProcessJobExecutionRequest(Long processEventId, Map<String, Object> opts) {
+		this.processEventId = processEventId;
+		this.opts = opts;
+	}
+
+	public Long getProcessEventId() {
+		return processEventId;
+	}
+
+	public void setProcessEventId(Long processEventId) {
+		this.processEventId = processEventId;
+	}
+
+	public Map<String, Object> getOpts() {
+		return opts;
+	}
+
+	public void setOpts(Map<String, Object> opts) {
+		this.opts = opts;
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/ProcessJobExecutionResponse.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/ProcessJobExecutionResponse.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model.process;
+
+import java.util.Map;
+
+/**
+ * Response model returned from {@link com.morpheusdata.core.providers.ProcessJobProvider#execute}.
+ * Contains optional outputs to forward to the next step in the process chain.
+ *
+ * @since 1.4.0
+ * @author Sean Ridgley
+ */
+public class ProcessJobExecutionResponse {
+
+	/**
+	 * Optional inputs for the next step. These are merged into the next event's {@code jobMsgConfig}
+	 * before it is dispatched.
+	 */
+	public Map<String, Object> nextOpts;
+
+	public ProcessJobExecutionResponse() {}
+
+	public ProcessJobExecutionResponse(Map<String, Object> nextOpts) {
+		this.nextOpts = nextOpts;
+	}
+
+	public Map<String, Object> getNextOpts() {
+		return nextOpts;
+	}
+
+	public void setNextOpts(Map<String, Object> nextOpts) {
+		this.nextOpts = nextOpts;
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/RunProcessStepRequest.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/RunProcessStepRequest.java
@@ -1,0 +1,62 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model.process;
+
+import com.morpheusdata.model.ProcessEvent;
+
+/**
+ * Request model for {@link com.morpheusdata.core.MorpheusProcessService#runProcessStep}.
+ * Identifies which process and step to dispatch for execution.
+ *
+ * @since 1.4.0
+ * @author Sean Ridgley
+ */
+public class RunProcessStepRequest {
+
+	/**
+	 * The process containing the step to run.
+	 */
+	public com.morpheusdata.model.Process process;
+
+	/**
+	 * The process event (step) to dispatch for execution.
+	 */
+	public ProcessEvent processEvent;
+
+	public RunProcessStepRequest() {}
+
+	public RunProcessStepRequest(com.morpheusdata.model.Process process, ProcessEvent processEvent) {
+		this.process = process;
+		this.processEvent = processEvent;
+	}
+
+	public com.morpheusdata.model.Process getProcess() {
+		return process;
+	}
+
+	public void setProcess(com.morpheusdata.model.Process process) {
+		this.process = process;
+	}
+
+	public ProcessEvent getProcessEvent() {
+		return processEvent;
+	}
+
+	public void setProcessEvent(ProcessEvent processEvent) {
+		this.processEvent = processEvent;
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/RunProcessStepResponse.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/RunProcessStepResponse.java
@@ -1,0 +1,45 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model.process;
+
+/**
+ * Response model returned from {@link com.morpheusdata.core.MorpheusProcessService#runProcessStep}.
+ *
+ * @since 1.4.0
+ * @author Sean Ridgley
+ */
+public class RunProcessStepResponse {
+
+	/**
+	 * Whether the step was successfully dispatched.
+	 */
+	public Boolean success;
+
+	public RunProcessStepResponse() {}
+
+	public RunProcessStepResponse(Boolean success) {
+		this.success = success;
+	}
+
+	public Boolean getSuccess() {
+		return success;
+	}
+
+	public void setSuccess(Boolean success) {
+		this.success = success;
+	}
+}


### PR DESCRIPTION
- Add ProcessJobProvider interface for plugin-based process job execution with support for option types, retry, cancel, and resume
- Add insertProcessStep/runProcessStep to MorpheusProcessService and synchronous variant for multi-step process orchestration
- Add eventTitle field to ProcessEvent model
- Add request/response DTOs: InsertProcessStepRequest/Response, RunProcessStepRequest/Response, ProcessJobExecutionRequest/Response