### PR TITLE
MORPH-6233 Add id field to ProcessEvent for runProcessStep dispatch

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ProcessEvent.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ProcessEvent.java
@@ -19,9 +19,15 @@ package com.morpheusdata.model;
 import java.util.Map;
 
 /**
- * Represents an event (or step) within a {@link Process}
+ * Represents an event (or step) within a {@link Process}.
+ * <p>
+ * Extends {@link MorpheusModel} to inherit the {@code id} field. When used as a parameter
+ * for {@link com.morpheusdata.core.MorpheusProcessService#runProcessStep}, the {@code id}
+ * should be set to the value returned by
+ * {@link com.morpheusdata.model.process.InsertProcessStepResponse#getProcessEventId()} so the
+ * platform can locate the persisted event to dispatch.
  */
-public class ProcessEvent {
+public class ProcessEvent extends MorpheusModel {
 
 	/**
 	 * @deprecated Use {@link #stepType} instead.


### PR DESCRIPTION
ProcessEvent was missing an id field, making it impossible to reference a previously inserted event when calling runProcessStep(). The InsertProcessStepResponse returns a processEventId but there was no way to set it back on a ProcessEvent to pass into RunProcessStepRequest.

Added Long id field with getter/setter and updated class Javadoc to document the insert-then-dispatch workflow.