### PR TITLE
Add MULTI_TEXT and MULTI_KEY_VALUE input types to OptionType.InputType

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/OptionType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/OptionType.java
@@ -1225,6 +1225,7 @@ public class OptionType extends MorpheusModel implements IModelUuidCodeName {
 		public static final InputType TEXTAREA = new InputType("textarea");
 		public static final InputType SELECT = new InputType("select");
 		public static final InputType MULTI_SELECT = new InputType("multiSelect");
+		public static final InputType MULTI_TEXT = new InputType("multiText");
 		public static final InputType CHECKBOX = new InputType("checkbox");
 		public static final InputType RADIO = new InputType("radio");
 		public static final InputType CREDENTIAL = new InputType("credential");

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/OptionType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/OptionType.java
@@ -1262,6 +1262,7 @@ public class OptionType extends MorpheusModel implements IModelUuidCodeName {
 		public static final InputType SELECT = new InputType("select");
 		public static final InputType MULTI_SELECT = new InputType("multiSelect");
 		public static final InputType MULTI_TEXT = new InputType("multiText");
+		public static final InputType MULTI_KEY_VALUE = new InputType("multiKeyValue");
 		public static final InputType CHECKBOX = new InputType("checkbox");
 		public static final InputType RADIO = new InputType("radio");
 		public static final InputType CREDENTIAL = new InputType("credential");

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/OptionType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/OptionType.java
@@ -1261,6 +1261,7 @@ public class OptionType extends MorpheusModel implements IModelUuidCodeName {
 		public static final InputType TEXTAREA = new InputType("textarea");
 		public static final InputType SELECT = new InputType("select");
 		public static final InputType MULTI_SELECT = new InputType("multiSelect");
+		public static final InputType MULTI_TEXT = new InputType("multiText");
 		public static final InputType CHECKBOX = new InputType("checkbox");
 		public static final InputType RADIO = new InputType("radio");
 		public static final InputType CREDENTIAL = new InputType("credential");

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/model/OptionTypeSpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/model/OptionTypeSpec.groovy
@@ -9,13 +9,15 @@ class OptionTypeSpec extends Specification {
 		str == inputType.toString()
 
 		where:
-		str           | inputType
-		'text'        | OptionType.InputType.TEXT
-		'textarea'    | OptionType.InputType.TEXTAREA
-		'number'      | OptionType.InputType.NUMBER
-		'checkbox'    | OptionType.InputType.CHECKBOX
-		'select'      | OptionType.InputType.SELECT
-		'radio'       | OptionType.InputType.RADIO
-		'code-editor' | OptionType.InputType.CODE_EDITOR
+		str            | inputType
+		'text'         | OptionType.InputType.TEXT
+		'textarea'     | OptionType.InputType.TEXTAREA
+		'number'       | OptionType.InputType.NUMBER
+		'checkbox'     | OptionType.InputType.CHECKBOX
+		'select'       | OptionType.InputType.SELECT
+		'multiSelect'  | OptionType.InputType.MULTI_SELECT
+		'multiText'    | OptionType.InputType.MULTI_TEXT
+		'radio'        | OptionType.InputType.RADIO
+		'code-editor'  | OptionType.InputType.CODE_EDITOR
 	}
 }

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/model/OptionTypeSpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/model/OptionTypeSpec.groovy
@@ -9,16 +9,16 @@ class OptionTypeSpec extends Specification {
 		str == inputType.toString()
 
 		where:
-		str            | inputType
-		'text'         | OptionType.InputType.TEXT
-		'textarea'     | OptionType.InputType.TEXTAREA
-		'number'       | OptionType.InputType.NUMBER
-		'checkbox'     | OptionType.InputType.CHECKBOX
-		'select'       | OptionType.InputType.SELECT
-		'multiSelect'  | OptionType.InputType.MULTI_SELECT
-		'multiText'    | OptionType.InputType.MULTI_TEXT
+		str             | inputType
+		'text'          | OptionType.InputType.TEXT
+		'textarea'      | OptionType.InputType.TEXTAREA
+		'number'        | OptionType.InputType.NUMBER
+		'checkbox'      | OptionType.InputType.CHECKBOX
+		'select'        | OptionType.InputType.SELECT
+		'multiSelect'   | OptionType.InputType.MULTI_SELECT
+		'multiText'     | OptionType.InputType.MULTI_TEXT
 		'multiKeyValue' | OptionType.InputType.MULTI_KEY_VALUE
-		'radio'        | OptionType.InputType.RADIO
-		'code-editor'  | OptionType.InputType.CODE_EDITOR
+		'radio'         | OptionType.InputType.RADIO
+		'code-editor'   | OptionType.InputType.CODE_EDITOR
 	}
 }

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/model/OptionTypeSpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/model/OptionTypeSpec.groovy
@@ -17,6 +17,7 @@ class OptionTypeSpec extends Specification {
 		'select'       | OptionType.InputType.SELECT
 		'multiSelect'  | OptionType.InputType.MULTI_SELECT
 		'multiText'    | OptionType.InputType.MULTI_TEXT
+		'multiKeyValue' | OptionType.InputType.MULTI_KEY_VALUE
 		'radio'        | OptionType.InputType.RADIO
 		'code-editor'  | OptionType.InputType.CODE_EDITOR
 	}

--- a/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
+++ b/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
@@ -5,6 +5,7 @@
 * **1.4.0**
 ** *Option Type Enhancements*
 *** Added `MULTI_TEXT` to `OptionType.InputType` so plugins can define multi-value text inputs (MORPH-6011).
+*** Added `MULTI_KEY_VALUE` to `OptionType.InputType` so plugins can define multi key-value pair inputs.
 
 * **1.3.4**
 ** *File Copy Enhancements*

--- a/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
+++ b/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
@@ -5,7 +5,7 @@
 * **1.4.0**
 ** *Option Type Enhancements*
 *** Added `MULTI_TEXT` to `OptionType.InputType` so plugins can define multi-value text inputs (MORPH-6011).
-*** Added `MULTI_KEY_VALUE` to `OptionType.InputType` so plugins can define multi key-value pair inputs.
+*** Added `MULTI_KEY_VALUE` to `OptionType.InputType` so plugins can define multiple key-value pair inputs.
 
 * **1.3.4**
 ** *File Copy Enhancements*

--- a/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
+++ b/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
@@ -2,6 +2,10 @@
 
 **Note:** Morpheus Plugin API is now 1.0! This means calls that are used will be supported for a longer period of time and given appropriate deprecation warnings when necessary. Morpheus Plugin API `1.3.x` requires a minimum Morpheus version of `8.1.x`. Morpheus Plugin API `1.2.x` requires Morpheus `8.0.x`, and Morpheus `7.0.x` runs on Core version `1.1.x`.
 
+* **1.4.0**
+** *Option Type Enhancements*
+*** Added `MULTI_TEXT` to `OptionType.InputType` so plugins can define multi-value text inputs (MORPH-6011).
+
 * **1.3.4**
 ** *File Copy Enhancements*
 *** Added `FileCopyRequest` support and new `generateUrl` overloads for file copy operations with Cloud context.


### PR DESCRIPTION
Adds two new InputType constants to OptionType so that plugin developers can declare multi-value form inputs that correspond to new input types introduced in the Morpheus UI.

  Changes

  MULTI_TEXT ("multiText")
  Allows plugins to define a field where users can enter multiple free-text values (e.g. a list of strings). Values are entered one at a time via a token/chip-style input.

  MULTI_KEY_VALUE ("multiKeyValue")
  Allows plugins to define a field where users can enter multiple key-value pairs (e.g. tags or environment variable-style entries).

  Files changed

   - OptionType.java — added MULTI_TEXT and MULTI_KEY_VALUE constants to the InputType inner class
   - OptionTypeSpec.groovy — added test coverage for both new input types
   - ReleaseNotes.adoc — documented both additions under the 1.4.0 release

  Notes

   - These constants mirror input types already implemented in the Morpheus UI; plugins using these types require a Morpheus version that includes the corresponding UI templates
   - No breaking changes; all existing InputType constants and behaviour are unchanged
