### PR TITLE
MORPH-4062: Add refresh/refreshDaily APIs for StorageServer, NetworkServer, and SystemComponent

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageServerService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageServerService.java
@@ -41,4 +41,20 @@ public interface MorpheusStorageServerService extends MorpheusDataService<Storag
 	Single<ServiceResponse> runConfigurationDriftCheck(CheckLevel checkLevel, StorageServer storageServer);
 
 	Single<ServiceResponse> getConfigurationDriftDetails(StorageServer storageServer);
+
+	/**
+	 * Trigger a short refresh on a storage server. This initiates a data sync/inventory refresh
+	 * of the storage server's resources.
+	 * @param storageServer storage server to refresh
+	 * @return Boolean returns the result of the storage server refresh request.
+	 */
+	Single<Boolean> refresh(StorageServer storageServer);
+
+	/**
+	 * Trigger a daily (full) refresh on a storage server. This initiates a full data sync
+	 * of the storage server's resources.
+	 * @param storageServer storage server to refresh
+	 * @return Boolean returns the result of the storage server refresh request.
+	 */
+	Single<Boolean> refreshDaily(StorageServer storageServer);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/MorpheusNetworkServerService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/MorpheusNetworkServerService.java
@@ -83,4 +83,20 @@ public interface MorpheusNetworkServerService extends MorpheusDataService<Networ
 
 	Single<ServiceResponse> getConfigurationDriftDetails(NetworkServer networkServer);
 
+	/**
+	 * Trigger a short refresh on a network server. This initiates a data sync/inventory refresh
+	 * of the network server's resources.
+	 * @param networkServer network server to refresh
+	 * @return Boolean returns the result of the network server refresh request.
+	 */
+	Single<Boolean> refresh(NetworkServer networkServer);
+
+	/**
+	 * Trigger a daily (full) refresh on a network server. This initiates a full data sync
+	 * of the network server's resources.
+	 * @param networkServer network server to refresh
+	 * @return Boolean returns the result of the network server refresh request.
+	 */
+	Single<Boolean> refreshDaily(NetworkServer networkServer);
+
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousStorageServerService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousStorageServerService.java
@@ -40,4 +40,20 @@ public interface MorpheusSynchronousStorageServerService extends MorpheusSynchro
 	Single<ServiceResponse> runConfigurationDriftCheck(CheckLevel checkLevel, StorageServer storageServer);
 
 	Single<ServiceResponse> getConfigurationDriftDetails(StorageServer storageServer);
+
+	/**
+	 * Trigger a short refresh on a storage server. This initiates a data sync/inventory refresh
+	 * of the storage server's resources.
+	 * @param storageServer storage server to refresh
+	 * @return Boolean returns the result of the storage server refresh request.
+	 */
+	Single<Boolean> refresh(StorageServer storageServer);
+
+	/**
+	 * Trigger a daily (full) refresh on a storage server. This initiates a full data sync
+	 * of the storage server's resources.
+	 * @param storageServer storage server to refresh
+	 * @return Boolean returns the result of the storage server refresh request.
+	 */
+	Single<Boolean> refreshDaily(StorageServer storageServer);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousStorageServerService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousStorageServerService.java
@@ -47,7 +47,7 @@ public interface MorpheusSynchronousStorageServerService extends MorpheusSynchro
 	 * @param storageServer storage server to refresh
 	 * @return Boolean returns the result of the storage server refresh request.
 	 */
-	Single<Boolean> refresh(StorageServer storageServer);
+	Boolean refresh(StorageServer storageServer);
 
 	/**
 	 * Trigger a daily (full) refresh on a storage server. This initiates a full data sync
@@ -55,5 +55,5 @@ public interface MorpheusSynchronousStorageServerService extends MorpheusSynchro
 	 * @param storageServer storage server to refresh
 	 * @return Boolean returns the result of the storage server refresh request.
 	 */
-	Single<Boolean> refreshDaily(StorageServer storageServer);
+	Boolean refreshDaily(StorageServer storageServer);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/network/MorpheusSynchronousNetworkServerService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/network/MorpheusSynchronousNetworkServerService.java
@@ -53,7 +53,7 @@ public interface MorpheusSynchronousNetworkServerService extends MorpheusSynchro
 	 * @param networkServer network server to refresh
 	 * @return Boolean returns the result of the network server refresh request.
 	 */
-	Single<Boolean> refresh(NetworkServer networkServer);
+	Boolean refresh(NetworkServer networkServer);
 
 	/**
 	 * Trigger a daily (full) refresh on a network server. This initiates a full data sync
@@ -61,5 +61,5 @@ public interface MorpheusSynchronousNetworkServerService extends MorpheusSynchro
 	 * @param networkServer network server to refresh
 	 * @return Boolean returns the result of the network server refresh request.
 	 */
-	Single<Boolean> refreshDaily(NetworkServer networkServer);
+	Boolean refreshDaily(NetworkServer networkServer);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/network/MorpheusSynchronousNetworkServerService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/network/MorpheusSynchronousNetworkServerService.java
@@ -46,4 +46,20 @@ public interface MorpheusSynchronousNetworkServerService extends MorpheusSynchro
 	Single<ServiceResponse> runConfigurationDriftCheck(CheckLevel checkLevel, NetworkServer networkServer);
 
 	Single<ServiceResponse> getConfigurationDriftDetails(NetworkServer networkServer);
+
+	/**
+	 * Trigger a short refresh on a network server. This initiates a data sync/inventory refresh
+	 * of the network server's resources.
+	 * @param networkServer network server to refresh
+	 * @return Boolean returns the result of the network server refresh request.
+	 */
+	Single<Boolean> refresh(NetworkServer networkServer);
+
+	/**
+	 * Trigger a daily (full) refresh on a network server. This initiates a full data sync
+	 * of the network server's resources.
+	 * @param networkServer network server to refresh
+	 * @return Boolean returns the result of the network server refresh request.
+	 */
+	Single<Boolean> refreshDaily(NetworkServer networkServer);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/system/MorpheusSynchronousSystemComponentService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/system/MorpheusSynchronousSystemComponentService.java
@@ -20,10 +20,29 @@ import com.morpheusdata.core.MorpheusSynchronousDataService;
 import com.morpheusdata.core.MorpheusSynchronousIdentityService;
 import com.morpheusdata.model.system.SystemComponent;
 import com.morpheusdata.model.projection.SystemComponentIdentityProjection;
+import io.reactivex.rxjava3.core.Single;
 
 /**
  * Synchronous access to {@link SystemComponent} objects via the plugin context.
  * Accessible via {@code morpheusContext.services.system.getComponent()}.
  */
 public interface MorpheusSynchronousSystemComponentService extends MorpheusSynchronousDataService<SystemComponent, SystemComponentIdentityProjection>, MorpheusSynchronousIdentityService<SystemComponentIdentityProjection> {
+
+	/**
+	 * Trigger a refresh on the underlying integration referenced by this system component.
+	 * Resolves the component's refType/refId and dispatches to the appropriate service refresh.
+	 * Supported refTypes: ComputeZone (Cloud), StorageServer, NetworkServer.
+	 * @param component the system component to refresh
+	 * @return Boolean returns the result of the refresh request.
+	 */
+	Single<Boolean> refreshComponent(SystemComponent component);
+
+	/**
+	 * Trigger a daily (full) refresh on the underlying integration referenced by this system component.
+	 * Resolves the component's refType/refId and dispatches to the appropriate service refresh.
+	 * Supported refTypes: ComputeZone (Cloud), StorageServer, NetworkServer.
+	 * @param component the system component to refresh
+	 * @return Boolean returns the result of the refresh request.
+	 */
+	Single<Boolean> refreshComponentDaily(SystemComponent component);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/system/MorpheusSynchronousSystemComponentService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/system/MorpheusSynchronousSystemComponentService.java
@@ -35,7 +35,7 @@ public interface MorpheusSynchronousSystemComponentService extends MorpheusSynch
 	 * @param component the system component to refresh
 	 * @return Boolean returns the result of the refresh request.
 	 */
-	Single<Boolean> refreshComponent(SystemComponent component);
+	Boolean refreshComponent(SystemComponent component);
 
 	/**
 	 * Trigger a daily (full) refresh on the underlying integration referenced by this system component.
@@ -44,5 +44,5 @@ public interface MorpheusSynchronousSystemComponentService extends MorpheusSynch
 	 * @param component the system component to refresh
 	 * @return Boolean returns the result of the refresh request.
 	 */
-	Single<Boolean> refreshComponentDaily(SystemComponent component);
+	Boolean refreshComponentDaily(SystemComponent component);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/system/MorpheusSystemComponentService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/system/MorpheusSystemComponentService.java
@@ -20,10 +20,29 @@ import com.morpheusdata.core.MorpheusDataService;
 import com.morpheusdata.core.MorpheusIdentityService;
 import com.morpheusdata.model.system.SystemComponent;
 import com.morpheusdata.model.projection.SystemComponentIdentityProjection;
+import io.reactivex.rxjava3.core.Single;
 
 /**
  * Provides access to {@link SystemComponent} objects via the plugin context.
  * Accessible via {@code morpheusContext.async.system.getComponent()}.
  */
 public interface MorpheusSystemComponentService extends MorpheusDataService<SystemComponent, SystemComponentIdentityProjection>, MorpheusIdentityService<SystemComponentIdentityProjection> {
+
+	/**
+	 * Trigger a refresh on the underlying integration referenced by this system component.
+	 * Resolves the component's refType/refId and dispatches to the appropriate service refresh.
+	 * Supported refTypes: ComputeZone (Cloud), StorageServer, NetworkServer.
+	 * @param component the system component to refresh
+	 * @return Boolean returns the result of the refresh request.
+	 */
+	Single<Boolean> refreshComponent(SystemComponent component);
+
+	/**
+	 * Trigger a daily (full) refresh on the underlying integration referenced by this system component.
+	 * Resolves the component's refType/refId and dispatches to the appropriate service refresh.
+	 * Supported refTypes: ComputeZone (Cloud), StorageServer, NetworkServer.
+	 * @param component the system component to refresh
+	 * @return Boolean returns the result of the refresh request.
+	 */
+	Single<Boolean> refreshComponentDaily(SystemComponent component);
 }


### PR DESCRIPTION
## Summary

Exposes plugin-accessible refresh APIs for StorageServer, NetworkServer, and SystemComponent so plugins (e.g. the System plugin) can trigger data syncs on other integrations.

## Changes

- **MorpheusStorageServerService** — added `refresh(StorageServer)` and `refreshDaily(StorageServer)`
- **MorpheusNetworkServerService** — added `refresh(NetworkServer)` and `refreshDaily(NetworkServer)`
- **MorpheusSystemComponentService** — added `refreshComponent(SystemComponent)` and `refreshComponentDaily(SystemComponent)` as unified dispatchers that resolve refType/refId and delegate to the appropriate service
- Synchronous variants updated to match

## Related
- MORPH-4062
- Companion UI PR in HPE-EMU/morpheus-ui