### PR TITLE
feat: Add MorpheusRoleService and MorpheusAccountService interfaces

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusAccountService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusAccountService.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.admin;
+
+import com.morpheusdata.core.MorpheusDataService;
+import com.morpheusdata.model.Account;
+
+/**
+ * Context methods for dealing with {@link Account} (tenants) in Morpheus.
+ * Provides CRUD operations for tenant/account management.
+ *
+ * @since 1.4.2
+ */
+public interface MorpheusAccountService extends MorpheusDataService<Account, Account> {
+
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusAdminService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusAdminService.java
@@ -67,4 +67,18 @@ public interface MorpheusAdminService {
 	 * @return an instance of the implementation of the {@link MorpheusPackageService}
 	 */
 	MorpheusPackageService getPackage();
+
+	/**
+	 * Returns the Role Service for creating and managing roles.
+	 * @return an instance of the implementation of the {@link MorpheusRoleService}
+	 * @since 1.4.2
+	 */
+	MorpheusRoleService getRole();
+
+	/**
+	 * Returns the Account Service for creating and managing tenants/accounts.
+	 * @return an instance of the implementation of the {@link MorpheusAccountService}
+	 * @since 1.4.2
+	 */
+	MorpheusAccountService getAccount();
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusRoleService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/admin/MorpheusRoleService.java
@@ -1,0 +1,30 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.admin;
+
+import com.morpheusdata.core.MorpheusDataService;
+import com.morpheusdata.model.Role;
+
+/**
+ * Context methods for dealing with {@link Role} in Morpheus.
+ * Provides CRUD operations for role management.
+ *
+ * @since 1.4.2
+ */
+public interface MorpheusRoleService extends MorpheusDataService<Role, Role> {
+
+}


### PR DESCRIPTION
## Summary

Adds service interfaces for Role and Account (tenant) CRUD operations, following the same pattern as `MorpheusComputeSiteService` and `MorpheusUserService`.

## New Interfaces

- `com.morpheusdata.core.admin.MorpheusRoleService` — extends `MorpheusDataService<Role, Role>`
- `com.morpheusdata.core.admin.MorpheusAccountService` — extends `MorpheusDataService<Account, Account>`

## Usage

Once impl services are registered in `MorpheusContextImplService`:
```groovy
// Create a role
Role role = new Role(authority: "DevOps", roleType: RoleType.user)
morpheusContext.services.role.create(role)

// Create a tenant
Account tenant = new Account(name: "Acme Corp")
morpheusContext.services.account.create(tenant)
```

## Related

- morpheus-ui impl: will add `MorpheusRoleImplService` and `MorpheusAccountImplService`
- Used by Blueprint push handler for creating roles/tenants on appliances