### PR TITLE
PCBE-62236: UI to Track Setup Installation Progress

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ConfigurationWorkflowProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ConfigurationWorkflowProvider.java
@@ -18,6 +18,7 @@ package com.morpheusdata.core.providers;
 
 import com.morpheusdata.response.ServiceResponse;
 import com.morpheusdata.model.ConfigurationWorkflow;
+import com.morpheusdata.model.ConfigurationWorkflowProgress;
 import com.morpheusdata.model.ConfigurationWorkflowStep;
 import com.morpheusdata.model.User;
 import java.util.List;
@@ -255,6 +256,26 @@ public interface ConfigurationWorkflowProvider extends PluginProvider {
 			Object parentObject,
 			Map<String, Object> opts) {
 		// Default implementation does nothing
+	}
+
+	/**
+	 * Optional method to retrieve the progress of a running configuration workflow.
+	 * This is used to track the execution status after the workflow has been submitted.
+	 * Returns a standardized {@link ConfigurationWorkflowProgress} structure containing
+	 * activities and their individual steps with completion percentages.
+	 *
+	 * <p>All system types that support progress tracking should override this method
+	 * and return a {@link ConfigurationWorkflowProgress} populated with the current
+	 * activity and step states.
+	 *
+	 * @param parentObject the parent object (e.g., System) that the workflow operates on
+	 * @param opts         additional options or context
+	 * @return ServiceResponse containing a {@link ConfigurationWorkflowProgress} with
+	 *         activity and step-level progress details
+	 */
+	default ServiceResponse<ConfigurationWorkflowProgress> getConfigurationWorkflowProgress(Object parentObject,
+			Map<String, Object> opts) {
+		return ServiceResponse.error("Progress tracking not supported");
 	}
 
 	/**

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ConfigurationWorkflowActivity.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ConfigurationWorkflowActivity.java
@@ -1,0 +1,101 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents a single activity phase within a configuration workflow progress.
+ * An activity corresponds to a major phase of the setup process (e.g., Precheck, Setup).
+ * Each activity tracks its own completion state and percentage, and may contain
+ * a list of individual steps that provide granular progress details.
+ *
+ * <p>Activity states:
+ * <ul>
+ *   <li>{@code Completed} — the activity has finished successfully</li>
+ *   <li>{@code Running} — the activity is currently executing</li>
+ *   <li>{@code Waiting} — the activity has not started yet</li>
+ *   <li>{@code Failed} — the activity encountered an error</li>
+ * </ul>
+ *
+ * @author Bhanu Sharma
+ * @since 1.4.1
+ */
+public class ConfigurationWorkflowActivity extends MorpheusModel {
+
+	protected String activityName;
+	protected String activityState;
+	protected String activityType;
+	protected Integer activityPercent = 0;
+	protected Boolean completed = false;
+	protected List<ConfigurationWorkflowActivityStep> steps = new ArrayList<>();
+
+	public String getActivityName() {
+		return activityName;
+	}
+
+	public void setActivityName(String activityName) {
+		this.activityName = activityName;
+		markDirty("activityName", activityName);
+	}
+
+	public String getActivityState() {
+		return activityState;
+	}
+
+	public void setActivityState(String activityState) {
+		this.activityState = activityState;
+		markDirty("activityState", activityState);
+	}
+
+	public String getActivityType() {
+		return activityType;
+	}
+
+	public void setActivityType(String activityType) {
+		this.activityType = activityType;
+		markDirty("activityType", activityType);
+	}
+
+	public Integer getActivityPercent() {
+		return activityPercent;
+	}
+
+	public void setActivityPercent(Integer activityPercent) {
+		this.activityPercent = activityPercent;
+		markDirty("activityPercent", activityPercent);
+	}
+
+	public Boolean getCompleted() {
+		return completed;
+	}
+
+	public void setCompleted(Boolean completed) {
+		this.completed = completed;
+		markDirty("completed", completed);
+	}
+
+	public List<ConfigurationWorkflowActivityStep> getSteps() {
+		return steps;
+	}
+
+	public void setSteps(List<ConfigurationWorkflowActivityStep> steps) {
+		this.steps = steps;
+		markDirty("steps", steps);
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ConfigurationWorkflowActivityStep.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ConfigurationWorkflowActivityStep.java
@@ -1,0 +1,87 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model;
+
+/**
+ * Represents a single step within a configuration workflow activity.
+ * Steps provide granular progress tracking for individual operations
+ * within an activity phase (e.g., StorageSetup, NetworkConfiguration).
+ *
+ * <p>Step states:
+ * <ul>
+ *   <li>{@code Completed} — the step has finished successfully</li>
+ *   <li>{@code Running} — the step is currently executing</li>
+ *   <li>{@code Waiting} — the step has not started yet</li>
+ *   <li>{@code Failed} — the step encountered an error</li>
+ * </ul>
+ *
+ * @author Bhanu Sharma
+ * @since 1.4.1
+ */
+public class ConfigurationWorkflowActivityStep extends MorpheusModel {
+
+	protected String name;
+	protected String stepState;
+	protected Integer percentComplete = 0;
+	protected String errorMessage;
+	protected String details;
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+		markDirty("name", name);
+	}
+
+	public String getStepState() {
+		return stepState;
+	}
+
+	public void setStepState(String stepState) {
+		this.stepState = stepState;
+		markDirty("stepState", stepState);
+	}
+
+	public Integer getPercentComplete() {
+		return percentComplete;
+	}
+
+	public void setPercentComplete(Integer percentComplete) {
+		this.percentComplete = percentComplete;
+		markDirty("percentComplete", percentComplete);
+	}
+
+	public String getErrorMessage() {
+		return errorMessage;
+	}
+
+	public void setErrorMessage(String errorMessage) {
+		this.errorMessage = errorMessage;
+		markDirty("errorMessage", errorMessage);
+	}
+
+	public String getDetails() {
+		return details;
+	}
+
+	public void setDetails(String details) {
+		this.details = details;
+		markDirty("details", details);
+	}
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ConfigurationWorkflowProgress.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ConfigurationWorkflowProgress.java
@@ -1,0 +1,57 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Represents the progress of a configuration workflow execution.
+ * Contains a list of activities that make up the overall workflow progress.
+ * Each activity represents a phase (e.g., Precheck, Setup) and may contain
+ * individual steps with their own progress tracking.
+ *
+ * <p>This model provides a standardized structure that all system types must
+ * follow when reporting configuration workflow progress, ensuring the frontend
+ * can render progress for any system type consistently.
+ *
+ * @author Bhanu Sharma
+ * @since 1.4.1
+ */
+public class ConfigurationWorkflowProgress extends MorpheusModel {
+
+	protected Boolean success = false;
+	protected List<ConfigurationWorkflowActivity> activities = new ArrayList<>();
+
+	public Boolean getSuccess() {
+		return success;
+	}
+
+	public void setSuccess(Boolean success) {
+		this.success = success;
+		markDirty("success", success);
+	}
+
+	public List<ConfigurationWorkflowActivity> getActivities() {
+		return activities;
+	}
+
+	public void setActivities(List<ConfigurationWorkflowActivity> activities) {
+		this.activities = activities;
+		markDirty("activities", activities);
+	}
+}


### PR DESCRIPTION
 ## Summary
 
 Adds a standardized progress tracking API to the `ConfigurationWorkflowProvider` interface, enabling plugins to report real-time setup progress during configuration workflow execution.
 
 ## Changes
 
 ### New interface method
 - `getConfigurationWorkflowProgress(Object parentObject, Map<String, Object> opts)` — default method on `ConfigurationWorkflowProvider` that plugins override to report their setup progress. Returns `ServiceResponse<ConfigurationWorkflowProgress>`.
 
 ### New models (`com.morpheusdata.model`)
 | Model | Purpose |
 |-------|---------|
 | `ConfigurationWorkflowProgress` | Top-level container: `success` flag + list of activities |
 | `ConfigurationWorkflowActivity` | Represents a phase (e.g., Precheck, Setup): name, state, type, percent, completed, list of steps |
 | `ConfigurationWorkflowActivityStep` | Granular step within an activity: name, stepState, percentComplete, errorMessage, details |
 
 ### Activity/Step states
 `Waiting` → `Running` → `Completed` / `Failed`
 
 ## Why
 
 Previously, there was no contract for plugins to report configuration workflow progress. The UI had no way to poll and render setup status. This provides a standardized structure so any system type plugin can implement progress reporting, and the frontend can render it consistently.
 
 ## Related PRs
 - morpheus-ui: `feature/configuration-workflow-progress` (consumes this API)
 https://github.com/HPE-EMU/morpheus-ui/pull/4505
