### PR TITLE
MORPH-9712: Add importSystem() default method to SystemProvider

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/SystemProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/SystemProvider.java
@@ -101,6 +101,22 @@ public interface SystemProvider extends PluginProvider {
 	default ServiceResponse updateSystemConfiguration(System system, SystemRequest request) { return ServiceResponse.success(); }
 
 	/**
+	 * Called when the user imports an existing system into Morpheus.
+	 * The system record has already been persisted with the name, type, and layout selected
+	 * by the user. The provider should discover/validate the system and populate any
+	 * additional fields or components as needed.
+	 *
+	 * <p>The default implementation is a no-op returning {@code ServiceResponse.success()}.
+	 * Providers that do not support import may leave this default in place.</p>
+	 *
+	 * @param system  the persisted plugin model for the system being imported
+	 * @param systemRequest carries configOptions from the import request payload
+	 * @return {@link ServiceResponse#success()} if the import succeeded;
+	 *         {@link ServiceResponse#error(String)} with a human-readable message otherwise
+	 */
+	default ServiceResponse importSystem(System system, SystemRequest systemRequest) { return ServiceResponse.success(); }
+
+	/**
 	 * Perform any cleanup/state reset operations required on removal of a system
 	 * @param system
 	 * @return

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/system/SystemTypeLayout.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/system/SystemTypeLayout.java
@@ -17,6 +17,7 @@ public class SystemTypeLayout extends MorpheusModel {
 	protected List<TaskSet> initializeWorkflows = new ArrayList<>();
 	protected List<TaskSet> updateWorkflows = new ArrayList<>();
 	protected Boolean enabled = true;
+	protected Boolean importable = false;
 	protected SystemType systemType;
 	@com.fasterxml.jackson.databind.annotation.JsonSerialize(using = com.morpheusdata.model.serializers.ModelAsIdOnlySerializer.class)
 	protected com.morpheusdata.model.ConfigurationWorkflow configurationWorkflow;
@@ -93,6 +94,15 @@ public class SystemTypeLayout extends MorpheusModel {
 		this.enabled = enabled;
 	}
 
+	public Boolean getImportable() {
+		return importable;
+	}
+
+	public void setImportable(Boolean importable) {
+		markDirty("importable", importable);
+		this.importable = importable;
+	}
+
 	public SystemType getSystemType() {
 		return systemType;
 	}
@@ -120,4 +130,6 @@ public class SystemTypeLayout extends MorpheusModel {
 				.filter(component -> component.getCode().equals(code))
 				.collect(Collectors.toList());
 	}
+
+
 }


### PR DESCRIPTION
## Summary

Adds a `default` no-op `importSystem()` method to the `SystemProvider` interface as part of MORPH-9712 (system import wizard).

## Changes

- `SystemProvider.java`: Added `importSystem(System system, SystemRequest systemRequest)` default method returning `ServiceResponse.success()`

Providers that support system import should override this method to discover/validate the system and populate additional fields or components. Providers that don't support import can leave the default in place (no-op / always succeeds).