### PR TITLE
[MORPH-12868] Add supportsOverridingPrimaryInterface to ProvisionType model

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ProvisionProvider.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/ProvisionProvider.java
@@ -386,6 +386,15 @@ public interface ProvisionProvider extends PluginProvider {
 	}
 
 	/**
+	 * Indicates if the primary network interface can be overridden by the user.
+	 * When true, the Primary checkbox is shown in the edit network interface form.
+	 * @return Boolean
+	 */
+	default public Boolean supportsOverridingPrimaryInterface() {
+		return false;
+	}
+
+	/**
 	 * Indicates if the current service plan can be changed on a reconfigure operation
 	 * @since 1.2.13
 	 * @return Boolean

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ProvisionType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ProvisionType.java
@@ -76,6 +76,7 @@ public class ProvisionType extends MorpheusModel implements IModelCodeName {
 	protected Boolean supportsConfigManagement = true;
 	protected Boolean hasSecurityGroupsOnNetworks = false;
 	protected Boolean supportsNetworkSelection = true;
+	protected Boolean supportsOverridingPrimaryInterface = false;
 	/**
 	 * Indicates whether a service plan can be changed when reconfiguring an instance of this provision type.
 	 * Default is true.
@@ -309,6 +310,10 @@ public class ProvisionType extends MorpheusModel implements IModelCodeName {
 
 	public Boolean getSupportsNetworkSelection() {
 		return supportsNetworkSelection;
+	}
+
+	public Boolean getSupportsOverridingPrimaryInterface() {
+		return supportsOverridingPrimaryInterface;
 	}
 
 	/**
@@ -599,6 +604,11 @@ public class ProvisionType extends MorpheusModel implements IModelCodeName {
 	public void setSupportsNetworkSelection(Boolean supportsNetworkSelection) {
 		this.supportsNetworkSelection = supportsNetworkSelection;
 		markDirty("supportsNetworkSelection", supportsNetworkSelection);
+	}
+
+	public void setSupportsOverridingPrimaryInterface(Boolean supportsOverridingPrimaryInterface) {
+		this.supportsOverridingPrimaryInterface = supportsOverridingPrimaryInterface;
+		markDirty("supportsOverridingPrimaryInterface", supportsOverridingPrimaryInterface);
 	}
 
 	/**


### PR DESCRIPTION
Adds supportsOverridingPrimaryInterface flag to ProvisionType model to support primary network interface assignment feature.

https://hpe.atlassian.net/browse/MORPH-12868