### PR TITLE
Add automatic plugin version/gitHash properties to all plugins

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/Plugin.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/Plugin.java
@@ -25,6 +25,7 @@ import com.morpheusdata.views.Renderer;
 import com.morpheusdata.web.PluginController;
 
 import java.util.*;
+import org.slf4j.MDC;
 
 /**
  * This is the base class for all Plugins that are instantiated within the Morpheus Environment. It contains both
@@ -510,6 +511,24 @@ public abstract class Plugin implements PluginInterface {
 		} catch (Exception ignored) {
 		}
 		return "unknown-build";
+	}
+
+	/**
+	 * Injects the plugin's version tag into the SLF4J MDC under the key {@code "pluginVersion"}
+	 * so it appears in every log line emitted on the calling thread.
+	 * <p>
+	 * Call this at the start of any method that runs on a thread-pool or RxJava thread, e.g.:
+	 * <pre>{@code
+	 * public void someWorkerMethod() {
+	 *     setVersionMDC();
+	 *     // ... rest of method
+	 * }
+	 * }</pre>
+	 *
+	 * @since 1.4.2
+	 */
+	public void setVersionMDC() {
+		MDC.put("pluginVersion", getVersionTag());
 	}
 
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/Plugin.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/Plugin.java
@@ -483,4 +483,33 @@ public abstract class Plugin implements PluginInterface {
 		return ServiceResponse.success();
 	}
 
+	/**
+	 * Returns a short build tag of the form {@code version-gitHash} loaded from the
+	 * {@code morpheus-plugin.properties} resource bundled into the plugin jar at build time
+	 * by the {@code com.morpheusdata.morpheus-plugin-gradle} Gradle plugin.
+	 * <p>
+	 * This is useful for logging the exact build that is running, e.g.:
+	 * <pre>{@code log.info("Starting {} plugin {}", getName(), getVersionTag());}</pre>
+	 * Returns {@code "unknown-build"} if the resource is missing (e.g. during local development
+	 * without a full build).
+	 *
+	 * @return a version+gitHash tag string identifying the running build
+	 * @since 1.4.2
+	 */
+	public String getVersionTag() {
+		try {
+			ClassLoader cl = classLoader != null ? classLoader : getClass().getClassLoader();
+			java.io.InputStream stream = cl.getResourceAsStream("morpheus-plugin.properties");
+			if (stream != null) {
+				java.util.Properties props = new java.util.Properties();
+				props.load(stream);
+				String v = props.getProperty("version", "unknown");
+				String h = props.getProperty("gitHash", "?????");
+				return v + "-" + h;
+			}
+		} catch (Exception ignored) {
+		}
+		return "unknown-build";
+	}
+
 }

--- a/morpheus-plugin-gradle/src/main/groovy/com/morpheusdata/gradle/MorpheusPlugin.groovy
+++ b/morpheus-plugin-gradle/src/main/groovy/com/morpheusdata/gradle/MorpheusPlugin.groovy
@@ -25,6 +25,7 @@ import org.gradle.language.jvm.tasks.ProcessResources
  * task: sribePackage - builds a manifest of your scribe packages
  * task: sribeResources - builds a manifest of your scribe resources
  * task: morpheusI18n - packages i18n properties files for localization efforts
+ * task: generatePluginVersionProperties - generates morpheus-plugin.properties with version and gitHash
  * @author bdwheeler
  */
 class MorpheusPlugin implements Plugin<Project> {
@@ -38,6 +39,8 @@ class MorpheusPlugin implements Plugin<Project> {
 		project.tasks.create('scribeResources', MorpheusScribeResources)
 		//setup i18n task
 		project.tasks.create('i18nPackage',MorpheusI18nPackage)
+		//setup version properties task
+		def generateVersionTask = project.tasks.create('generatePluginVersionProperties')
 		//get the package task
 		def scribePackageTask = project.tasks.getByName('scribePackage')
 		def scribeResourcesTask = project.tasks.getByName('scribeResources')
@@ -69,6 +72,19 @@ class MorpheusPlugin implements Plugin<Project> {
 				i18nTarget = project.file("${processResources?.destinationDir}/${morpheusPluginConfig.i18nTarget}")
 			}
 
+			//configure version properties task: generate morpheus-plugin.properties into a build directory
+			//and add it as a resource source so every plugin automatically gets version+gitHash at runtime
+			def generatedResDir = new File(project.buildDir, 'generated-resources/morpheus-plugin')
+			generateVersionTask.configure {
+				outputs.upToDateWhen { false }
+				outputs.dir generatedResDir
+				doLast {
+					def gitHash = ['git', 'rev-parse', '--short=5', 'HEAD'].execute().text.trim() ?: 'unknown'
+					generatedResDir.mkdirs()
+					new File(generatedResDir, 'morpheus-plugin.properties').text =
+						"version=${project.version}\ngitHash=${gitHash}\n"
+				}
+			}
 
 			//add task dependencies
 			
@@ -82,6 +98,11 @@ class MorpheusPlugin implements Plugin<Project> {
 
 			if(project.file(morpheusPluginConfig.i18nDir).exists()) {
 				processResources.dependsOn(morpheusI18nPackageTask)
+			}
+
+			if(processResources) {
+				processResources.from(generatedResDir)
+				processResources.dependsOn(generateVersionTask)
 			}
 			
 		}


### PR DESCRIPTION
## Summary

Generalizes the version+gitHash logging pattern from `morpheus-olvm-plugin` so it works automatically in every plugin — without requiring any changes to existing plugin build scripts.

## Changes

### `morpheus-plugin-gradle` — new Gradle task
Registers a `generatePluginVersionProperties` task that:
- Captures `project.version` and the short git hash at build time
- Writes `morpheus-plugin.properties` into `build/generated-resources/morpheus-plugin/` and adds that directory as a resource source
- Hooks into `processResources` automatically, so the file is bundled into every plugin jar

### `morpheus-plugin-api` — new `Plugin.getVersionTag()` method
Reads `morpheus-plugin.properties` from the plugin's own classloader and returns a `"version-gitHash"` string (e.g. `"1.1.11-69f75"`). Falls back to `"unknown-build"` if the resource is missing (e.g. local dev without a full build).

## Usage

Any plugin can now log its build tag on startup:
```java
log.info("Starting {} plugin {}", getName(), getVersionTag());
```

No changes are required to existing plugins — the Gradle task wires itself in automatically via `com.morpheusdata.morpheus-plugin-gradle`.
