### PR TITLE
MORPH-6233: Add System-scoped startProcess overloads to process servi…

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusProcessService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusProcessService.java
@@ -18,6 +18,7 @@ package com.morpheusdata.core;
 
 import com.morpheusdata.model.*;
 import com.morpheusdata.model.Process;
+import com.morpheusdata.model.system.System;
 import com.morpheusdata.model.process.InsertProcessStepRequest;
 import com.morpheusdata.model.process.InsertProcessStepResponse;
 import com.morpheusdata.model.process.RunProcessStepRequest;
@@ -93,7 +94,31 @@ public interface MorpheusProcessService extends MorpheusDataService<Process, Pro
 	Single<Process> startProcess(Workload workload, ProcessStepType stepType, User user, String timerCategory, String eventTitle);
 
 	/**
-	 * Start a new ProcessEvent associated to the Process. This will end any currently running
+	 * Start a new Process for the System. Unlike the Workload-based overloads, this associates the Process
+	 * to a System ({@code refType='system'}, {@code refId=system.id}) and does not require a Workload.
+	 * @param system the System to associate the Process to
+	 * @param stepType the ProcessStepType to start
+	 * @param user the User that starts the process (optional)
+	 * @param timerCategory a category to associate with this Process. The category is used to provide estimated
+	 *                      durations for a Process based on previous run of processes with this same category.
+	 * @return the started Process
+	 */
+	Single<Process> startProcess(System system, ProcessStepType stepType, User user, String timerCategory);
+
+	/**
+	 * Start a new Process for the System. Unlike the Workload-based overloads, this associates the Process
+	 * to a System ({@code refType='system'}, {@code refId=system.id}) and does not require a Workload.
+	 * @param system the System to associate the Process to
+	 * @param stepType the ProcessStepType to start
+	 * @param user the User that starts the process (optional)
+	 * @param timerCategory a category to associate with this Process. The category is used to provide estimated
+	 *                      durations for a Process based on previous run of processes with this same category.
+	 * @param eventTitle an event title to associate with this Process
+	 * @return the started Process
+	 */
+	Single<Process> startProcess(System system, ProcessStepType stepType, User user, String timerCategory, String eventTitle);
+
+	/**
 	 * ProcessEvents associated to the Process
 	 * @param process The Process on which to create a new ProcessEvent to start
 	 * @param nextEvent The new ProcessEvent to start

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousProcessService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousProcessService.java
@@ -7,6 +7,7 @@ import com.morpheusdata.model.ProcessStepType;
 import com.morpheusdata.model.ProcessStepUpdate;
 import com.morpheusdata.model.User;
 import com.morpheusdata.model.Workload;
+import com.morpheusdata.model.system.System;
 import com.morpheusdata.model.process.InsertProcessStepRequest;
 import com.morpheusdata.model.process.InsertProcessStepResponse;
 import com.morpheusdata.model.process.RunProcessStepRequest;
@@ -36,6 +37,31 @@ public interface MorpheusSynchronousProcessService extends MorpheusSynchronousDa
 	 * @return Boolean indicating success
 	 */
 	Process startProcess(Workload workload, ProcessStepType stepType, User user, String timerCategory, String eventTitle);
+
+	/**
+	 * Start a new Process for the System. Unlike the Workload-based overloads, this associates the Process
+	 * to a System ({@code refType='system'}, {@code refId=system.id}) and does not require a Workload.
+	 * @param system the System to associate the Process to
+	 * @param stepType the ProcessStepType to start
+	 * @param user the User that starts the process (optional)
+	 * @param timerCategory a category to associate with this Process. The category is used to provide estimated
+	 *                      durations for a Process based on previous run of processes with this same category.
+	 * @return the started Process
+	 */
+	Process startProcess(System system, ProcessStepType stepType, User user, String timerCategory);
+
+	/**
+	 * Start a new Process for the System. Unlike the Workload-based overloads, this associates the Process
+	 * to a System ({@code refType='system'}, {@code refId=system.id}) and does not require a Workload.
+	 * @param system the System to associate the Process to
+	 * @param stepType the ProcessStepType to start
+	 * @param user the User that starts the process (optional)
+	 * @param timerCategory a category to associate with this Process. The category is used to provide estimated
+	 *                      durations for a Process based on previous run of processes with this same category.
+	 * @param eventTitle an event title to associate with this Process
+	 * @return the started Process
+	 */
+	Process startProcess(System system, ProcessStepType stepType, User user, String timerCategory, String eventTitle);
 
 	/**
 	 * Start a new ProcessEvent associated to the Process. This will end any currently running


### PR DESCRIPTION
…ce API

Declare startProcess(System, ...) overloads on MorpheusProcessService and MorpheusSynchronousProcessService so plugins can start a Process associated to a System (refType='system') without a Workload.