### PR TITLE
feat(storage): add MorpheusGfs2FilesystemService for GFS2 operations

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusStorageService.java
@@ -17,6 +17,7 @@
 package com.morpheusdata.core;
 
 import com.morpheusdata.core.network.MorpheusNetworkServerService;
+import com.morpheusdata.core.storage.MorpheusGfs2FilesystemService;
 import com.morpheusdata.model.CheckLevel;
 import com.morpheusdata.model.NetworkServer;
 import com.morpheusdata.model.StorageServer;
@@ -72,6 +73,18 @@ public interface MorpheusStorageService {
 	 * @since 1.3.0
 	 */
 	MorpheusStorageAggregateService getAggregate();
+
+	/**
+	 * Returns the GFS2 Filesystem Service for shared storage operations.
+	 * <p>
+	 * This service provides operations for setting up and managing GFS2 filesystems
+	 * on shared block storage devices, including filesystem creation, mounting,
+	 * and libvirt storage pool management.
+	 *
+	 * @return An instance of the GFS2 Filesystem Service
+	 * @since 1.5.0
+	 */
+	MorpheusGfs2FilesystemService getGfs2Filesystem();
 
 	/**
 	 * Validates an update on a {@link StorageServer} before executing the update.

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusSynchronousStorageService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusSynchronousStorageService.java
@@ -17,6 +17,7 @@
 package com.morpheusdata.core;
 
 import com.morpheusdata.core.storage.MorpheusDatastoreTypeService;
+import com.morpheusdata.core.storage.MorpheusGfs2FilesystemService;
 import com.morpheusdata.core.storage.MorpheusVmeQcow2DatastoreService;
 import com.morpheusdata.core.synchronous.*;
 import com.morpheusdata.model.CheckLevel;
@@ -77,6 +78,18 @@ public interface MorpheusSynchronousStorageService {
 	 * @return An instance of the DatastoreType Service
 	 */
 	MorpheusDatastoreTypeService getDatastoreType();
+
+	/**
+	 * Returns the GFS2 Filesystem Service for shared storage operations.
+	 * <p>
+	 * This service provides operations for setting up and managing GFS2 filesystems
+	 * on shared block storage devices, including filesystem creation, mounting,
+	 * and libvirt storage pool management.
+	 *
+	 * @return An instance of the GFS2 Filesystem Service
+	 * @since 1.5.0
+	 */
+	MorpheusGfs2FilesystemService getGfs2Filesystem();
 
 	/**
 	 * Validates an update on a {@link StorageServer} before executing the update.

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/storage/Gfs2CleanupRequest.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/storage/Gfs2CleanupRequest.java
@@ -1,0 +1,179 @@
+/*
+ *  Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.storage;
+
+import com.morpheusdata.model.ComputeServerGroup;
+import com.morpheusdata.model.Datastore;
+
+/**
+ * Request object for {@link MorpheusGfs2FilesystemService#cleanupFilesystem}.
+ * <p>
+ * Use the builder pattern for construction:
+ * <pre>{@code
+ * Gfs2CleanupRequest request = Gfs2CleanupRequest.builder()
+ *     .datastore(datastore)
+ *     .serverGroup(serverGroup)
+ *     .executionMode(ExecutionMode.AGENT)
+ *     .wipeFilesystem(false)
+ *     .force(false)
+ *     .build();
+ * }</pre>
+ *
+ * @since 1.5.0
+ * @author HPE
+ */
+public class Gfs2CleanupRequest {
+
+    private final Datastore datastore;
+    private final ComputeServerGroup serverGroup;
+    private final MorpheusGfs2FilesystemService.ExecutionMode executionMode;
+    private final boolean wipeFilesystem;
+    private final boolean force;
+
+    private Gfs2CleanupRequest(Builder builder) {
+        this.datastore = builder.datastore;
+        this.serverGroup = builder.serverGroup;
+        this.executionMode = builder.executionMode;
+        this.wipeFilesystem = builder.wipeFilesystem;
+        this.force = builder.force;
+    }
+
+    /**
+     * The data store to clean up.
+     * @return the data store
+     */
+    public Datastore getDatastore() {
+        return datastore;
+    }
+
+    /**
+     * The server group (cluster) to unmount from.
+     * @return the server group
+     */
+    public ComputeServerGroup getServerGroup() {
+        return serverGroup;
+    }
+
+    /**
+     * How mounts were managed (must match setup).
+     * @return the execution mode
+     */
+    public MorpheusGfs2FilesystemService.ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    /**
+     * If true, wipes the GFS2 filesystem signature after unmount.
+     * @return true if filesystem should be wiped
+     */
+    public boolean isWipeFilesystem() {
+        return wipeFilesystem;
+    }
+
+    /**
+     * If true, force unmount even if busy (may cause data loss).
+     * @return true if force unmount
+     */
+    public boolean isForce() {
+        return force;
+    }
+
+    /**
+     * Creates a new builder for Gfs2CleanupRequest.
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing {@link Gfs2CleanupRequest} instances.
+     */
+    public static class Builder {
+        private Datastore datastore;
+        private ComputeServerGroup serverGroup;
+        private MorpheusGfs2FilesystemService.ExecutionMode executionMode =
+                MorpheusGfs2FilesystemService.ExecutionMode.AGENT;
+        private boolean wipeFilesystem = false;
+        private boolean force = false;
+
+        /**
+         * Sets the data store to clean up.
+         * @param datastore the data store
+         * @return this builder
+         */
+        public Builder datastore(Datastore datastore) {
+            this.datastore = datastore;
+            return this;
+        }
+
+        /**
+         * Sets the server group (cluster).
+         * @param serverGroup the server group
+         * @return this builder
+         */
+        public Builder serverGroup(ComputeServerGroup serverGroup) {
+            this.serverGroup = serverGroup;
+            return this;
+        }
+
+        /**
+         * Sets the execution mode for unmount management.
+         * @param executionMode AGENT or PACEMAKER
+         * @return this builder
+         */
+        public Builder executionMode(MorpheusGfs2FilesystemService.ExecutionMode executionMode) {
+            this.executionMode = executionMode;
+            return this;
+        }
+
+        /**
+         * Sets whether to wipe the filesystem after unmount.
+         * @param wipeFilesystem true to wipe, false to preserve
+         * @return this builder
+         */
+        public Builder wipeFilesystem(boolean wipeFilesystem) {
+            this.wipeFilesystem = wipeFilesystem;
+            return this;
+        }
+
+        /**
+         * Sets whether to force unmount.
+         * @param force true to force unmount even if busy
+         * @return this builder
+         */
+        public Builder force(boolean force) {
+            this.force = force;
+            return this;
+        }
+
+        /**
+         * Builds the request, validating required fields.
+         * @return the constructed request
+         * @throws IllegalArgumentException if required fields are missing
+         */
+        public Gfs2CleanupRequest build() {
+            if (datastore == null) {
+                throw new IllegalArgumentException("datastore is required");
+            }
+            if (serverGroup == null) {
+                throw new IllegalArgumentException("serverGroup is required");
+            }
+            return new Gfs2CleanupRequest(this);
+        }
+    }
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/storage/Gfs2OperationResult.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/storage/Gfs2OperationResult.java
@@ -1,0 +1,263 @@
+/*
+ *  Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.storage;
+
+import java.util.Collections;
+import java.util.Map;
+
+/**
+ * Result of a GFS2 filesystem operation.
+ * <p>
+ * Contains detailed information about success or failure, including
+ * which phase failed and per-node status.
+ * <p>
+ * <b>Usage Example:</b>
+ * <pre>{@code
+ * Gfs2OperationResult result = gfs2Service.setupFilesystem(request).blockingGet();
+ * if (!result.isSuccess()) {
+ *     log.error("GFS2 setup failed at phase {}: {}",
+ *         result.getFailedPhase(), result.getMessage());
+ *     // Check per-node results for partial failures
+ *     result.getNodeResults().forEach((uuid, nodeResult) -> {
+ *         if (!nodeResult.isSuccess()) {
+ *             log.error("Node {} failed: {}", nodeResult.getServerName(),
+ *                 nodeResult.getMessage());
+ *         }
+ *     });
+ * }
+ * }</pre>
+ *
+ * @since 1.5.0
+ * @author HPE
+ */
+public class Gfs2OperationResult {
+
+    /**
+     * Phases of GFS2 setup/cleanup operations.
+     */
+    public enum Phase {
+        /** Input validation phase */
+        VALIDATION,
+        /** mkfs.gfs2 filesystem creation phase */
+        MKFS,
+        /** Mount filesystem on nodes phase */
+        MOUNT,
+        /** Create/start virsh storage pool phase */
+        VIRSH_POOL,
+        /** Unmount filesystem from nodes phase */
+        UNMOUNT,
+        /** Wipe filesystem signature phase */
+        WIPE,
+        /** Operation completed successfully */
+        COMPLETE
+    }
+
+    private final boolean success;
+    private final String message;
+    private final Phase failedPhase;
+    private final Map<String, NodeResult> nodeResults;
+    private final Throwable exception;
+
+    private Gfs2OperationResult(
+            boolean success,
+            String message,
+            Phase failedPhase,
+            Map<String, NodeResult> nodeResults,
+            Throwable exception
+    ) {
+        this.success = success;
+        this.message = message;
+        this.failedPhase = failedPhase;
+        this.nodeResults = nodeResults != null
+                ? Collections.unmodifiableMap(nodeResults)
+                : Collections.emptyMap();
+        this.exception = exception;
+    }
+
+    /**
+     * True if the operation completed successfully on all nodes.
+     * @return true if successful
+     */
+    public boolean isSuccess() {
+        return success;
+    }
+
+    /**
+     * Human-readable message describing the result.
+     * @return the result message
+     */
+    public String getMessage() {
+        return message;
+    }
+
+    /**
+     * The phase where failure occurred, or COMPLETE if successful.
+     * @return the failed phase or COMPLETE
+     */
+    public Phase getFailedPhase() {
+        return failedPhase;
+    }
+
+    /**
+     * Per-node results keyed by server UUID.
+     * Useful for diagnosing partial failures.
+     * @return unmodifiable map of node results
+     */
+    public Map<String, NodeResult> getNodeResults() {
+        return nodeResults;
+    }
+
+    /**
+     * The exception if one was thrown, null otherwise.
+     * @return the exception or null
+     */
+    public Throwable getException() {
+        return exception;
+    }
+
+    /**
+     * Creates a success result with a message.
+     * @param message the success message
+     * @return a successful result
+     */
+    public static Gfs2OperationResult success(String message) {
+        return new Gfs2OperationResult(true, message, Phase.COMPLETE, null, null);
+    }
+
+    /**
+     * Creates a success result with a message and per-node results.
+     * @param message the success message
+     * @param nodeResults per-node operation results
+     * @return a successful result
+     */
+    public static Gfs2OperationResult success(String message, Map<String, NodeResult> nodeResults) {
+        return new Gfs2OperationResult(true, message, Phase.COMPLETE, nodeResults, null);
+    }
+
+    /**
+     * Creates a failure result with a message and failed phase.
+     * @param message the failure message
+     * @param failedPhase the phase where failure occurred
+     * @return a failed result
+     */
+    public static Gfs2OperationResult failure(String message, Phase failedPhase) {
+        return new Gfs2OperationResult(false, message, failedPhase, null, null);
+    }
+
+    /**
+     * Creates a failure result with a message, failed phase, and per-node results.
+     * @param message the failure message
+     * @param failedPhase the phase where failure occurred
+     * @param nodeResults per-node operation results
+     * @return a failed result
+     */
+    public static Gfs2OperationResult failure(
+            String message,
+            Phase failedPhase,
+            Map<String, NodeResult> nodeResults
+    ) {
+        return new Gfs2OperationResult(false, message, failedPhase, nodeResults, null);
+    }
+
+    /**
+     * Creates a failure result with a message, failed phase, and exception.
+     * @param message the failure message
+     * @param failedPhase the phase where failure occurred
+     * @param exception the exception that caused the failure
+     * @return a failed result
+     */
+    public static Gfs2OperationResult failure(
+            String message,
+            Phase failedPhase,
+            Throwable exception
+    ) {
+        return new Gfs2OperationResult(false, message, failedPhase, null, exception);
+    }
+
+    /**
+     * Result for a single node in the cluster.
+     */
+    public static class NodeResult {
+        private final String serverUuid;
+        private final String serverName;
+        private final boolean success;
+        private final String message;
+        private final Phase completedPhase;
+
+        /**
+         * Creates a node result.
+         * @param serverUuid the server UUID
+         * @param serverName the server name for display
+         * @param success whether the operation succeeded on this node
+         * @param message descriptive message
+         * @param completedPhase the last phase completed on this node
+         */
+        public NodeResult(
+                String serverUuid,
+                String serverName,
+                boolean success,
+                String message,
+                Phase completedPhase
+        ) {
+            this.serverUuid = serverUuid;
+            this.serverName = serverName;
+            this.success = success;
+            this.message = message;
+            this.completedPhase = completedPhase;
+        }
+
+        /**
+         * The server UUID.
+         * @return the server UUID
+         */
+        public String getServerUuid() {
+            return serverUuid;
+        }
+
+        /**
+         * The server name for display purposes.
+         * @return the server name
+         */
+        public String getServerName() {
+            return serverName;
+        }
+
+        /**
+         * Whether the operation succeeded on this node.
+         * @return true if successful
+         */
+        public boolean isSuccess() {
+            return success;
+        }
+
+        /**
+         * Descriptive message about the operation on this node.
+         * @return the message
+         */
+        public String getMessage() {
+            return message;
+        }
+
+        /**
+         * The last phase completed on this node.
+         * @return the completed phase
+         */
+        public Phase getCompletedPhase() {
+            return completedPhase;
+        }
+    }
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/storage/Gfs2SetupRequest.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/storage/Gfs2SetupRequest.java
@@ -1,0 +1,260 @@
+/*
+ *  Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.storage;
+
+import com.morpheusdata.model.ComputeServerGroup;
+import com.morpheusdata.model.Datastore;
+import com.morpheusdata.model.StorageVolume;
+
+/**
+ * Request object for {@link MorpheusGfs2FilesystemService#setupFilesystem}.
+ * <p>
+ * Use the builder pattern for construction:
+ * <pre>{@code
+ * Gfs2SetupRequest request = Gfs2SetupRequest.builder()
+ *     .datastore(datastore)
+ *     .serverGroup(serverGroup)
+ *     .storageVolume(storageVolume)
+ *     .devicePath("/dev/mapper/mpatha")
+ *     .clusterName("alletra-gfs2-cluster")
+ *     .lockTableName("alletra:gfs2data:alletra-gfs2-cluster")
+ *     .executionMode(ExecutionMode.AGENT)
+ *     .build();
+ * }</pre>
+ *
+ * @since 1.5.0
+ * @author HPE
+ */
+public class Gfs2SetupRequest {
+
+    private final Datastore datastore;
+    private final ComputeServerGroup serverGroup;
+    private final StorageVolume storageVolume;
+    private final String devicePath;
+    private final String clusterName;
+    private final String lockTableName;
+    private final MorpheusGfs2FilesystemService.ExecutionMode executionMode;
+    private final boolean formatIfExists;
+
+    private Gfs2SetupRequest(Builder builder) {
+        this.datastore = builder.datastore;
+        this.serverGroup = builder.serverGroup;
+        this.storageVolume = builder.storageVolume;
+        this.devicePath = builder.devicePath;
+        this.clusterName = builder.clusterName;
+        this.lockTableName = builder.lockTableName;
+        this.executionMode = builder.executionMode;
+        this.formatIfExists = builder.formatIfExists;
+    }
+
+    /**
+     * The data store entity (must be persisted before calling).
+     * @return the data store
+     */
+    public Datastore getDatastore() {
+        return datastore;
+    }
+
+    /**
+     * The server group (cluster) where filesystem will be mounted.
+     * @return the server group
+     */
+    public ComputeServerGroup getServerGroup() {
+        return serverGroup;
+    }
+
+    /**
+     * The storage volume backing the filesystem.
+     * @return the storage volume
+     */
+    public StorageVolume getStorageVolume() {
+        return storageVolume;
+    }
+
+    /**
+     * The block device path on the hosts (e.g., "/dev/mapper/mpatha").
+     * Must be the same path visible on all cluster nodes.
+     * @return the device path
+     */
+    public String getDevicePath() {
+        return devicePath;
+    }
+
+    /**
+     * The GFS2 cluster name for mkfs.gfs2 -t option.
+     * @return the cluster name
+     */
+    public String getClusterName() {
+        return clusterName;
+    }
+
+    /**
+     * The GFS2 lock table name (format: "clustername:fsname:locktable").
+     * Used for DLM lock coordination.
+     * @return the lock table name
+     */
+    public String getLockTableName() {
+        return lockTableName;
+    }
+
+    /**
+     * How to manage mounts across the cluster.
+     * @return the execution mode
+     */
+    public MorpheusGfs2FilesystemService.ExecutionMode getExecutionMode() {
+        return executionMode;
+    }
+
+    /**
+     * If true, reformats an existing GFS2 filesystem.
+     * Default is false (preserve existing filesystem).
+     * @return true if should format even if filesystem exists
+     */
+    public boolean isFormatIfExists() {
+        return formatIfExists;
+    }
+
+    /**
+     * Creates a new builder for Gfs2SetupRequest.
+     * @return a new builder instance
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    /**
+     * Builder for constructing {@link Gfs2SetupRequest} instances.
+     */
+    public static class Builder {
+        private Datastore datastore;
+        private ComputeServerGroup serverGroup;
+        private StorageVolume storageVolume;
+        private String devicePath;
+        private String clusterName;
+        private String lockTableName;
+        private MorpheusGfs2FilesystemService.ExecutionMode executionMode =
+                MorpheusGfs2FilesystemService.ExecutionMode.AGENT;
+        private boolean formatIfExists = false;
+
+        /**
+         * Sets the data store entity.
+         * @param datastore the data store (must be persisted)
+         * @return this builder
+         */
+        public Builder datastore(Datastore datastore) {
+            this.datastore = datastore;
+            return this;
+        }
+
+        /**
+         * Sets the server group (cluster).
+         * @param serverGroup the server group
+         * @return this builder
+         */
+        public Builder serverGroup(ComputeServerGroup serverGroup) {
+            this.serverGroup = serverGroup;
+            return this;
+        }
+
+        /**
+         * Sets the storage volume.
+         * @param storageVolume the storage volume
+         * @return this builder
+         */
+        public Builder storageVolume(StorageVolume storageVolume) {
+            this.storageVolume = storageVolume;
+            return this;
+        }
+
+        /**
+         * Sets the block device path.
+         * @param devicePath the device path (e.g., "/dev/mapper/mpatha")
+         * @return this builder
+         */
+        public Builder devicePath(String devicePath) {
+            this.devicePath = devicePath;
+            return this;
+        }
+
+        /**
+         * Sets the GFS2 cluster name.
+         * @param clusterName the cluster name
+         * @return this builder
+         */
+        public Builder clusterName(String clusterName) {
+            this.clusterName = clusterName;
+            return this;
+        }
+
+        /**
+         * Sets the GFS2 lock table name.
+         * @param lockTableName the lock table name
+         * @return this builder
+         */
+        public Builder lockTableName(String lockTableName) {
+            this.lockTableName = lockTableName;
+            return this;
+        }
+
+        /**
+         * Sets the execution mode for mount management.
+         * @param executionMode AGENT or PACEMAKER
+         * @return this builder
+         */
+        public Builder executionMode(MorpheusGfs2FilesystemService.ExecutionMode executionMode) {
+            this.executionMode = executionMode;
+            return this;
+        }
+
+        /**
+         * Sets whether to reformat an existing filesystem.
+         * @param formatIfExists true to reformat, false to preserve
+         * @return this builder
+         */
+        public Builder formatIfExists(boolean formatIfExists) {
+            this.formatIfExists = formatIfExists;
+            return this;
+        }
+
+        /**
+         * Builds the request, validating required fields.
+         * @return the constructed request
+         * @throws IllegalArgumentException if required fields are missing
+         */
+        public Gfs2SetupRequest build() {
+            if (datastore == null) {
+                throw new IllegalArgumentException("datastore is required");
+            }
+            if (serverGroup == null) {
+                throw new IllegalArgumentException("serverGroup is required");
+            }
+            if (storageVolume == null) {
+                throw new IllegalArgumentException("storageVolume is required");
+            }
+            if (devicePath == null || devicePath.isEmpty()) {
+                throw new IllegalArgumentException("devicePath is required");
+            }
+            if (clusterName == null || clusterName.isEmpty()) {
+                throw new IllegalArgumentException("clusterName is required");
+            }
+            if (lockTableName == null || lockTableName.isEmpty()) {
+                throw new IllegalArgumentException("lockTableName is required");
+            }
+            return new Gfs2SetupRequest(this);
+        }
+    }
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/storage/MorpheusGfs2FilesystemService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/storage/MorpheusGfs2FilesystemService.java
@@ -1,0 +1,137 @@
+/*
+ *  Copyright 2026 Hewlett Packard Enterprise Development LP
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.storage;
+
+import com.morpheusdata.model.ComputeServerGroup;
+import com.morpheusdata.model.Datastore;
+import com.morpheusdata.model.StorageVolume;
+import io.reactivex.rxjava3.core.Single;
+
+/**
+ * Plugin API service for GFS2 filesystem operations on shared block storage.
+ * <p>
+ * This service handles the host-side setup of GFS2 filesystems including:
+ * <ul>
+ *   <li>Creating the GFS2 filesystem on a shared block device</li>
+ *   <li>Mounting the filesystem via agent or pacemaker on cluster nodes</li>
+ *   <li>Creating/starting the libvirt storage pool on hypervisors</li>
+ * </ul>
+ * <p>
+ * <b>Thread Safety:</b> All methods are thread-safe. The service handles internal
+ * synchronization for cluster-wide operations.
+ * <p>
+ * <b>Idempotency:</b> All methods are idempotent. Calling setupFilesystem() on an
+ * already-configured filesystem will verify the existing state and return success.
+ * <p>
+ * <b>Usage Example:</b>
+ * <pre>{@code
+ * Gfs2SetupRequest request = Gfs2SetupRequest.builder()
+ *     .datastore(datastore)
+ *     .serverGroup(serverGroup)
+ *     .storageVolume(storageVolume)
+ *     .devicePath("/dev/mapper/mpatha")
+ *     .clusterName("alletra-gfs2-cluster")
+ *     .lockTableName("alletra:gfs2data:alletra-gfs2-cluster")
+ *     .executionMode(ExecutionMode.AGENT)
+ *     .build();
+ *
+ * Gfs2OperationResult result = morpheusContext.getServices().getStorage()
+ *     .getGfs2Filesystem()
+ *     .setupFilesystem(request)
+ *     .blockingGet();
+ * }</pre>
+ *
+ * @since 1.5.0
+ * @author HPE
+ */
+public interface MorpheusGfs2FilesystemService {
+
+    /**
+     * Execution mode for GFS2 operations.
+     * <p>
+     * Determines how mounts and unmounts are managed across the cluster.
+     */
+    enum ExecutionMode {
+        /**
+         * Use morpheus agent for mount management.
+         * Suitable for shared SAN storage where an external cluster manager
+         * (e.g., storage array) handles failover.
+         */
+        AGENT,
+
+        /**
+         * Use pacemaker/corosync for cluster resource management.
+         * Suitable when pacemaker manages the GFS2 resource lifecycle.
+         */
+        PACEMAKER
+    }
+
+    /**
+     * Sets up a GFS2 filesystem on the specified storage volume and mounts it
+     * across all nodes in the server group.
+     * <p>
+     * Operations performed:
+     * <ol>
+     *   <li><b>mkfs.gfs2</b> — Creates the GFS2 filesystem (skipped if already exists)</li>
+     *   <li><b>Mount</b> — Mounts filesystem on each cluster node via agent or pacemaker</li>
+     *   <li><b>Libvirt pool</b> — Creates and starts virsh storage pool on each hypervisor</li>
+     * </ol>
+     * <p>
+     * <b>Prerequisites:</b>
+     * <ul>
+     *   <li>Storage volume must be exported to all nodes in the server group</li>
+     *   <li>Block device must be visible on all nodes (multipath configured if applicable)</li>
+     *   <li>Data store entity must be persisted (flush GORM session) before calling</li>
+     * </ul>
+     *
+     * @param request the setup request containing all required parameters
+     * @return Single emitting the result with success/failure and details
+     */
+    Single<Gfs2OperationResult> setupFilesystem(Gfs2SetupRequest request);
+
+    /**
+     * Removes a GFS2 filesystem setup from all nodes in the server group.
+     * <p>
+     * Operations performed (in reverse order):
+     * <ol>
+     *   <li><b>Libvirt pool</b> — Destroys and undefines virsh storage pool</li>
+     *   <li><b>Unmount</b> — Unmounts filesystem from each cluster node</li>
+     *   <li><b>Cleanup</b> — Optionally wipes the filesystem signature</li>
+     * </ol>
+     *
+     * @param request the cleanup request containing all required parameters
+     * @return Single emitting the result with success/failure and details
+     */
+    Single<Gfs2OperationResult> cleanupFilesystem(Gfs2CleanupRequest request);
+
+    /**
+     * Refreshes the GFS2 filesystem state on all nodes.
+     * <p>
+     * Use this after adding or removing nodes from the cluster to ensure
+     * consistent mount state across all members.
+     *
+     * @param datastore     the data store to refresh
+     * @param serverGroup   the server group (cluster) containing the nodes
+     * @param executionMode how to manage mounts (agent or pacemaker)
+     * @return Single emitting the result with success/failure and details
+     */
+    Single<Gfs2OperationResult> refreshFilesystem(
+            Datastore datastore,
+            ComputeServerGroup serverGroup,
+            ExecutionMode executionMode
+    );
+}


### PR DESCRIPTION
Add new plugin API service for GFS2 filesystem operations on shared block storage. This service allows plugins to set up GFS2 filesystems without going through the lock-protected DatastoreTypeService path, preventing deadlock during data store creation.

New files:
- MorpheusGfs2FilesystemService: Main service interface with setupFilesystem(), cleanupFilesystem(), and refreshFilesystem() methods
- Gfs2SetupRequest: Builder-pattern request for filesystem setup
- Gfs2CleanupRequest: Builder-pattern request for filesystem cleanup
- Gfs2OperationResult: Result object with phase info and per-node status

Updated:
- MorpheusStorageService: Added getGfs2Filesystem() method

Resolves deadlock issue in Alletra MP plugin GFS2 data store creation where plugin's createDatastore() runs inside DatastoreTypeService lock and needs to delegate host-side operations to gfs2DatastoreService.