### PR TITLE
MORPH-13446 fix UTF-8 encoding for HTTP request bodies

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/HttpApiClient.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/HttpApiClient.java
@@ -82,6 +82,7 @@ import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.*;
 import java.security.cert.X509Certificate;
 import java.security.KeyManagementException;
@@ -372,14 +373,14 @@ public class HttpApiClient {
 						DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ssZ");
 						mapper.setDateFormat(df);
 						mapper.registerModule(new SimpleModule().addSerializer(CharSequence.class, new GStringJsonSerializer()));
-						postRequest.setEntity(new StringEntity(mapper.writeValueAsString(opts.body)));
+						postRequest.setEntity(new StringEntity(mapper.writeValueAsString(opts.body), ContentType.APPLICATION_JSON));
 					}
 				} else if (opts.body instanceof byte[]) {
 					postRequest.setEntity(new ByteArrayEntity((byte[]) opts.body));
 				} else if (opts.body instanceof InputStream) {
 					postRequest.setEntity(new InputStreamEntity((InputStream) (opts.body), opts.contentLength != null ? opts.contentLength : -1));
 				} else {
-					postRequest.setEntity(new StringEntity(opts.body.toString()));
+					postRequest.setEntity(new StringEntity(opts.body.toString(), StandardCharsets.UTF_8));
 				}
 			}
 
@@ -682,7 +683,7 @@ public class HttpApiClient {
 						ObjectMapper mapper = new ObjectMapper();
 						DateFormat df = new SimpleDateFormat("yyyy-MM-dd'T'hh:mm:ssZ");
 						mapper.setDateFormat(df);
-						postRequest.setEntity(new StringEntity(mapper.writeValueAsString(opts.body)));
+						postRequest.setEntity(new StringEntity(mapper.writeValueAsString(opts.body), ContentType.APPLICATION_JSON));
 
 					}
 				} else if (opts.body instanceof byte[]) {
@@ -690,7 +691,7 @@ public class HttpApiClient {
 				} else if (opts.body instanceof InputStream) {
 					postRequest.setEntity(new InputStreamEntity((InputStream) (opts.body), opts.contentLength != null ? opts.contentLength : -1));
 				} else {
-					postRequest.setEntity(new StringEntity(opts.body.toString()));
+					postRequest.setEntity(new StringEntity(opts.body.toString(), StandardCharsets.UTF_8));
 				}
 			}
 

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/RestApiUtil.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/RestApiUtil.java
@@ -75,6 +75,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.security.KeyManagementException;
 import java.security.KeyStoreException;
 import java.security.NoSuchAlgorithmException;
@@ -226,12 +227,12 @@ public class RestApiUtil {
 							request.setHeader("Content-Type", newValue);
 						}
 					} else {
-						postRequest.setEntity(new StringEntity(JsonOutput.toJson(opts.body)));
+						postRequest.setEntity(new StringEntity(JsonOutput.toJson(opts.body), ContentType.APPLICATION_JSON));
 					}
 				} else if(opts.body instanceof byte[]) {
 					postRequest.setEntity(new ByteArrayEntity((byte[])opts.body));
 				} else {
-					postRequest.setEntity(new StringEntity(opts.body.toString()));
+					postRequest.setEntity(new StringEntity(opts.body.toString(), StandardCharsets.UTF_8));
 				}
 			}
 


### PR DESCRIPTION
<img width="581" height="214" alt="Screenshot 2026-07-01 at 11 45 55 AM" src="https://github.com/user-attachments/assets/94b17882-b0b5-43a5-ac8e-12e9638a4e51" />

## Summary

Fixes server-side character corruption in AI chat responses. `StringEntity` was constructed without a charset, defaulting to ISO-8859-1 and replacing non-Latin-1 characters (emoji, bullets, box-drawing) with `?` in outbound request bodies.

## Problem

When conversation history containing multi-byte Unicode characters is sent back to the AI provider, `new StringEntity(string)` encodes with ISO-8859-1 (Apache HttpClient default). Characters outside Latin-1 are silently replaced with `?`. The AI then sees corrupted context and echoes the `?` characters back.

Reproduced via Playwright: first response shows emoji correctly, but follow-up turns corrupt them to `?????` when history is re-sent.

## Fix

- JSON bodies (Jackson-serialized): `new StringEntity(json, ContentType.APPLICATION_JSON)` (UTF-8 by default)
- Plain string bodies (fallback): `new StringEntity(str, StandardCharsets.UTF_8)`

Applied at all 6 affected `StringEntity` construction sites across both files.

## Files Changed

- `morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/HttpApiClient.java` (4 sites)
- `morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/RestApiUtil.java` (2 sites)

## Testing

- Compiles clean (`./gradlew :morpheus-plugin-api:compileJava`)
- Verified end-to-end locally by publishing to mavenLocal and restarting the app
- Playwright confirmed corruption reproduced before fix, resolved after