### PR TITLE
MORPH-13940: Add updateProcessMessage/updateProcessError to plugin API

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusProcessService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusProcessService.java
@@ -238,4 +238,50 @@ public interface MorpheusProcessService extends MorpheusDataService<Process, Pro
 	 * @return A RunProcessStepResponse indicating whether the dispatch was successful
 	 */
 	Single<RunProcessStepResponse> runProcessStep(RunProcessStepRequest request);
+
+	/**
+	 * Update the message on a Process, verifying it belongs to the given System.
+	 * The process is validated against {@code refType='system'} and {@code refId=systemId}
+	 * to guard against updating the wrong process.
+	 * @param process The Process to update (as returned by {@link #startProcess(System, ProcessStepType, User, String)})
+	 * @param systemId The ID of the System the process should belong to
+	 * @param message The message to set on the process
+	 * @return Single emitting true if the process was found, validated, and updated; false otherwise
+	 * @since 1.5.0
+	 */
+	Single<Boolean> updateProcessMessage(Process process, Long systemId, String message);
+
+	/**
+	 * Update the message on a Process, verifying it matches the given refType and refId.
+	 * @param process The Process to update
+	 * @param refType The expected reference type (e.g. 'system', 'instance', 'computeServer')
+	 * @param refId The expected reference ID of the associated entity
+	 * @param message The message to set on the process
+	 * @return Single emitting true if the process was found, validated, and updated; false otherwise
+	 * @since 1.5.0
+	 */
+	Single<Boolean> updateProcessMessage(Process process, String refType, Long refId, String message);
+
+	/**
+	 * Update the error on a Process, verifying it belongs to the given System.
+	 * The process is validated against {@code refType='system'} and {@code refId=systemId}
+	 * to guard against updating the wrong process.
+	 * @param process The Process to update (as returned by {@link #startProcess(System, ProcessStepType, User, String)})
+	 * @param systemId The ID of the System the process should belong to
+	 * @param error The error to set on the process
+	 * @return Single emitting true if the process was found, validated, and updated; false otherwise
+	 * @since 1.5.0
+	 */
+	Single<Boolean> updateProcessError(Process process, Long systemId, String error);
+
+	/**
+	 * Update the error on a Process, verifying it matches the given refType and refId.
+	 * @param process The Process to update
+	 * @param refType The expected reference type (e.g. 'system', 'instance', 'computeServer')
+	 * @param refId The expected reference ID of the associated entity
+	 * @param error The error to set on the process
+	 * @return Single emitting true if the process was found, validated, and updated; false otherwise
+	 * @since 1.5.0
+	 */
+	Single<Boolean> updateProcessError(Process process, String refType, Long refId, String error);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousProcessService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousProcessService.java
@@ -157,18 +157,6 @@ public interface MorpheusSynchronousProcessService extends MorpheusSynchronousDa
 	RunProcessStepResponse runProcessStep(RunProcessStepRequest request);
 
 	/**
-	 * Update the message on a Process, verifying it belongs to the given System.
-	 * The process is validated against {@code refType='system'} and {@code refId=systemId}
-	 * to guard against updating the wrong process.
-	 * @param process The Process to update (as returned by {@link #startProcess(System, ProcessStepType, User, String)})
-	 * @param systemId The ID of the System the process should belong to
-	 * @param message The message to set on the process
-	 * @return true if the process was found, validated, and updated; false otherwise
-	 * @since 1.5.0
-	 */
-	Boolean updateProcessMessage(Process process, Long systemId, String message);
-
-	/**
 	 * Update the message on a Process, verifying it matches the given refType and refId.
 	 * @param process The Process to update
 	 * @param refType The expected reference type (e.g. 'system', 'instance', 'computeServer')
@@ -178,18 +166,6 @@ public interface MorpheusSynchronousProcessService extends MorpheusSynchronousDa
 	 * @since 1.5.0
 	 */
 	Boolean updateProcessMessage(Process process, String refType, Long refId, String message);
-
-	/**
-	 * Update the error on a Process, verifying it belongs to the given System.
-	 * The process is validated against {@code refType='system'} and {@code refId=systemId}
-	 * to guard against updating the wrong process.
-	 * @param process The Process to update (as returned by {@link #startProcess(System, ProcessStepType, User, String)})
-	 * @param systemId The ID of the System the process should belong to
-	 * @param error The error to set on the process
-	 * @return true if the process was found, validated, and updated; false otherwise
-	 * @since 1.5.0
-	 */
-	Boolean updateProcessError(Process process, Long systemId, String error);
 
 	/**
 	 * Update the error on a Process, verifying it matches the given refType and refId.

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousProcessService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousProcessService.java
@@ -155,4 +155,50 @@ public interface MorpheusSynchronousProcessService extends MorpheusSynchronousDa
 	 * @return A RunProcessStepResponse indicating whether the dispatch was successful
 	 */
 	RunProcessStepResponse runProcessStep(RunProcessStepRequest request);
+
+	/**
+	 * Update the message on a Process, verifying it belongs to the given System.
+	 * The process is validated against {@code refType='system'} and {@code refId=systemId}
+	 * to guard against updating the wrong process.
+	 * @param process The Process to update (as returned by {@link #startProcess(System, ProcessStepType, User, String)})
+	 * @param systemId The ID of the System the process should belong to
+	 * @param message The message to set on the process
+	 * @return true if the process was found, validated, and updated; false otherwise
+	 * @since 1.5.0
+	 */
+	Boolean updateProcessMessage(Process process, Long systemId, String message);
+
+	/**
+	 * Update the message on a Process, verifying it matches the given refType and refId.
+	 * @param process The Process to update
+	 * @param refType The expected reference type (e.g. 'system', 'instance', 'computeServer')
+	 * @param refId The expected reference ID of the associated entity
+	 * @param message The message to set on the process
+	 * @return true if the process was found, validated, and updated; false otherwise
+	 * @since 1.5.0
+	 */
+	Boolean updateProcessMessage(Process process, String refType, Long refId, String message);
+
+	/**
+	 * Update the error on a Process, verifying it belongs to the given System.
+	 * The process is validated against {@code refType='system'} and {@code refId=systemId}
+	 * to guard against updating the wrong process.
+	 * @param process The Process to update (as returned by {@link #startProcess(System, ProcessStepType, User, String)})
+	 * @param systemId The ID of the System the process should belong to
+	 * @param error The error to set on the process
+	 * @return true if the process was found, validated, and updated; false otherwise
+	 * @since 1.5.0
+	 */
+	Boolean updateProcessError(Process process, Long systemId, String error);
+
+	/**
+	 * Update the error on a Process, verifying it matches the given refType and refId.
+	 * @param process The Process to update
+	 * @param refType The expected reference type (e.g. 'system', 'instance', 'computeServer')
+	 * @param refId The expected reference ID of the associated entity
+	 * @param error The error to set on the process
+	 * @return true if the process was found, validated, and updated; false otherwise
+	 * @since 1.5.0
+	 */
+	Boolean updateProcessError(Process process, String refType, Long refId, String error);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/Process.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/Process.java
@@ -16,6 +16,8 @@
 
 package com.morpheusdata.model;
 
+import java.util.Date;
+
 public class Process extends MorpheusModel {
 
 	public ProcessStepType stepType;
@@ -27,6 +29,42 @@ public class Process extends MorpheusModel {
 	public ProcessEvent.ProcessType type;
 
 	public String username;
+
+	/**
+	 * The process status (e.g. 'pending', 'running', 'complete', 'failed').
+	 * @since 1.5.0
+	 */
+	public String status;
+
+	/**
+	 * The process-level message. Shown in the history detail when the process status is not 'failed'.
+	 * @since 1.5.0
+	 */
+	public String message;
+
+	/**
+	 * The process-level error. Shown in the history detail when the process status is 'failed'.
+	 * @since 1.5.0
+	 */
+	public String error;
+
+	/**
+	 * Progress percentage (0-100).
+	 * @since 1.5.0
+	 */
+	public Double percent;
+
+	/**
+	 * When the process was started.
+	 * @since 1.5.0
+	 */
+	public Date startDate;
+
+	/**
+	 * When the process ended. Null if still active.
+	 * @since 1.5.0
+	 */
+	public Date endDate;
 
 	/**
 	 * @deprecated Use {@link #getStepType() } instead.

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/Process.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/Process.java
@@ -17,6 +17,7 @@
 package com.morpheusdata.model;
 
 import java.util.Date;
+import java.util.List;
 
 public class Process extends MorpheusModel {
 
@@ -65,6 +66,77 @@ public class Process extends MorpheusModel {
 	 * @since 1.5.0
 	 */
 	public Date endDate;
+
+	/**
+	 * Display name for this process (e.g. instance name, server name).
+	 * @since 1.5.0
+	 */
+	public String displayName;
+
+	/**
+	 * The event title for this process (e.g. "Configuring Networking").
+	 * @since 1.5.0
+	 */
+	public String eventTitle;
+
+	/**
+	 * The name of the process.
+	 * @since 1.5.0
+	 */
+	public String name;
+
+	/**
+	 * Description of this process.
+	 * @since 1.5.0
+	 */
+	public String description;
+
+	/**
+	 * The process events (steps) associated with this process.
+	 * Populated when loading a process with its full detail.
+	 * @since 1.5.0
+	 */
+	public List<ProcessEvent> processEvents;
+
+	public String getDisplayName() {
+		return displayName;
+	}
+
+	public void setDisplayName(String displayName) {
+		this.displayName = displayName;
+	}
+
+	public String getEventTitle() {
+		return eventTitle;
+	}
+
+	public void setEventTitle(String eventTitle) {
+		this.eventTitle = eventTitle;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public String getDescription() {
+		return description;
+	}
+
+	public void setDescription(String description) {
+		this.description = description;
+	}
+
+	public List<ProcessEvent> getProcessEvents() {
+		return processEvents;
+	}
+
+	public void setProcessEvents(List<ProcessEvent> processEvents) {
+		this.processEvents = processEvents;
+	}
 
 	/**
 	 * @deprecated Use {@link #getStepType() } instead.

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ProcessEvent.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ProcessEvent.java
@@ -16,6 +16,7 @@
 
 package com.morpheusdata.model;
 
+import java.util.Date;
 import java.util.Map;
 
 /**
@@ -37,6 +38,60 @@ public class ProcessEvent extends MorpheusModel {
 	public String eventTitle;
 	public String jobName;
 	public Map jobConfig;
+
+	/**
+	 * The event status (e.g. 'pending', 'queued', 'running', 'complete', 'failed').
+	 * @since 1.5.0
+	 */
+	public String status;
+
+	/**
+	 * The event message. Shown in the history detail when the event status is not 'failed'.
+	 * @since 1.5.0
+	 */
+	public String message;
+
+	/**
+	 * Process event output text (e.g. command output, log content).
+	 * @since 1.5.0
+	 */
+	public String output;
+
+	/**
+	 * Error text for the event. Shown in the history detail when the event status is 'failed'.
+	 * @since 1.5.0
+	 */
+	public String error;
+
+	/**
+	 * When the event was started.
+	 * @since 1.5.0
+	 */
+	public Date startDate;
+
+	/**
+	 * When the event ended. Null if still active.
+	 * @since 1.5.0
+	 */
+	public Date endDate;
+
+	/**
+	 * Display name for the event.
+	 * @since 1.5.0
+	 */
+	public String name;
+
+	/**
+	 * Whether this event step can be retried on failure.
+	 * @since 1.5.0
+	 */
+	public Boolean retryable;
+
+	/**
+	 * Whether this event step can be cancelled.
+	 * @since 1.5.0
+	 */
+	public Boolean cancelable;
 
 	/**
 	 * @deprecated Use {@link #getStepType()} instead.
@@ -96,6 +151,78 @@ public class ProcessEvent extends MorpheusModel {
 
 	public void setJobConfig(Map jobConfig) {
 		this.jobConfig = jobConfig;
+	}
+
+	public String getStatus() {
+		return status;
+	}
+
+	public void setStatus(String status) {
+		this.status = status;
+	}
+
+	public String getMessage() {
+		return message;
+	}
+
+	public void setMessage(String message) {
+		this.message = message;
+	}
+
+	public String getOutput() {
+		return output;
+	}
+
+	public void setOutput(String output) {
+		this.output = output;
+	}
+
+	public String getError() {
+		return error;
+	}
+
+	public void setError(String error) {
+		this.error = error;
+	}
+
+	public Date getStartDate() {
+		return startDate;
+	}
+
+	public void setStartDate(Date startDate) {
+		this.startDate = startDate;
+	}
+
+	public Date getEndDate() {
+		return endDate;
+	}
+
+	public void setEndDate(Date endDate) {
+		this.endDate = endDate;
+	}
+
+	public String getName() {
+		return name;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public Boolean getRetryable() {
+		return retryable;
+	}
+
+	public void setRetryable(Boolean retryable) {
+		this.retryable = retryable;
+	}
+
+	public Boolean getCancelable() {
+		return cancelable;
+	}
+
+	public void setCancelable(Boolean cancelable) {
+		this.cancelable = cancelable;
 	}
 
 	/**

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/ProcessJobExecutionResponse.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/process/ProcessJobExecutionResponse.java
@@ -33,6 +33,27 @@ public class ProcessJobExecutionResponse {
 	 */
 	public Map<String, Object> nextOpts;
 
+	/**
+	 * Optional message to record on the completed process step. Shown in the history detail pane
+	 * when the step status is not 'failed'.
+	 * @since 1.5.0
+	 */
+	public String message;
+
+	/**
+	 * Optional output to record on the completed process step. Shown in the output pane of the
+	 * history detail modal.
+	 * @since 1.5.0
+	 */
+	public String output;
+
+	/**
+	 * Optional error to record on the failed process step. Shown in the history detail pane
+	 * when the step status is 'failed'. Only applied during failure handling.
+	 * @since 1.5.0
+	 */
+	public String error;
+
 	public ProcessJobExecutionResponse() {}
 
 	public ProcessJobExecutionResponse(Map<String, Object> nextOpts) {


### PR DESCRIPTION
- Add message, error, status, percent, startDate, endDate fields to Process model
- Add updateProcessMessage and updateProcessError methods to MorpheusProcessService (reactive)
- Add updateProcessMessage and updateProcessError methods to MorpheusSynchronousProcessService (blocking)
- Methods accept a Process + systemId or refType/refId to validate ownership before updating
- Enables plugins to update process-level message/error with safety guard against wrong process