### PR TITLE
MORPH-14095: Add BackupRepository and ManagedServer resource types

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ResourcePermission.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/ResourcePermission.java
@@ -24,10 +24,12 @@ public class ResourcePermission extends ResourcePermissionIdentity {
 
 
 	public enum ResourceType {
+		BackupRepository,
 		BackupServer,
 		ComputeZoneFolder,
 		ComputeZonePool,
 		Datastore,
+		ManagedServer,
 		Network,
 		NetworkDomain,
 		NetworkEdgeCluster,


### PR DESCRIPTION
## Summary

Adds `BackupRepository` and `ManagedServer` to `ResourcePermission.ResourceType`.

This supports porting the embedded Veeam/Commvault backup option sources into their plugins as dataset providers ([MORPH-14095](https://hpe.atlassian.net/browse/MORPH-14095)). The Veeam dataset providers filter accessible resources via the non-deprecated `resourcePermission` service, which requires these resource types on `ResourcePermission.ResourceType` (previously they only existed on the deprecated `Permission.ResourceType`).

## Runtime safety

`MorpheusResourcePermissionImplService.listAccessibleResources` passes `resourceType.toString()` to `resourcesAccessibleByAccount(...)`. The new enum names (`BackupRepository`, `ManagedServer`) produce exactly the string literals the embedded option sources already used, so no morpheus-ui change is required.

## Note

The Veeam/Commvault plugin PRs (on `api-1.5.x`) build against this change; it needs to be merged and `1.5.0-SNAPSHOT` published for those plugins to compile against a released artifact.