### PR TITLE
Replace silent error handling with SLF4J logging in morpheus-plugin-api

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/Plugin.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/Plugin.java
@@ -25,6 +25,8 @@ import com.morpheusdata.views.Renderer;
 import com.morpheusdata.web.PluginController;
 
 import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This is the base class for all Plugins that are instantiated within the Morpheus Environment. It contains both
@@ -48,6 +50,7 @@ import java.util.*;
  * @author David Estes
  */
 public abstract class Plugin implements PluginInterface {
+	static Logger log = LoggerFactory.getLogger(Plugin.class);
 
 	/**
 	 * All registered plugin providers by provider code.
@@ -465,10 +468,10 @@ public abstract class Plugin implements PluginInterface {
 		try {
 			PluginProvider existingProvider = pluginProviders.get(provider.getCode());
 			if(existingProvider != null && provider.getClass() != existingProvider.getClass()) {
-				System.out.println("Plugin Provider Code Overlap Detected: " + provider.getCode() + ". Provider \"" + provider.getName() + "\" with type " + provider.getClass().getSimpleName() + " will replace provider \"" + existingProvider.getName() + "\" with type " + existingProvider.getClass().getSimpleName() + ".");
+				log.warn("Plugin Provider Code Overlap Detected: {}. Provider \"{}\" with type {} will replace provider \"{}\" with type {}.", provider.getCode(), provider.getName(), provider.getClass().getSimpleName(), existingProvider.getName(), existingProvider.getClass().getSimpleName());
 			}
 		} catch (Exception e) {
-			System.out.println("Error checking for provider conflict: " + e.getMessage());
+			log.error("Error checking for provider conflict: {}", e.getMessage(), e);
 		}
 	}
 

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/PluginManager.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/PluginManager.java
@@ -152,11 +152,10 @@ public class PluginManager {
 		try {
 			Class<Plugin> pluginClass = (Class<Plugin>) pluginLoader.loadClass(pluginClassName);
 
-			System.out.println("Loading Plugin " + pluginClassName + ":" + pluginVersion + " from " +  pathToJar);
+			log.info("Loading Plugin {}:{} from {}", pluginClassName, pluginVersion, pathToJar);
 			return registerPlugin(pluginClass, jarFile, pluginVersion);
 		} catch (Throwable e) {
-			System.out.println("Unable to load plugin class from " + pathToJar);
-			e.printStackTrace();
+			log.error("Unable to load plugin class from {} - {}", pathToJar, e.getMessage(), e);
 			return null;
 		}
 	}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/ConnectionUtils.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/ConnectionUtils.java
@@ -17,6 +17,8 @@
 package com.morpheusdata.core.util;
 
 import com.morpheusdata.model.NetworkProxy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.Proxy;
 import java.net.InetSocketAddress;
@@ -33,6 +35,7 @@ import java.util.concurrent.TimeUnit;
  * @since 0.8.0
  */
 public class ConnectionUtils {
+	static Logger log = LoggerFactory.getLogger(ConnectionUtils.class);
 	static Boolean testHostConnectivity(String hostname) {
 		return testHostConnectivity(hostname,null,true,true,null);
 	}
@@ -58,7 +61,7 @@ public class ConnectionUtils {
 				}
 
 			} catch(Exception e) {
-//				log.warn("test host connection failed: ${hostname} ${e.message}")
+				log.debug("test host connection failed: {} {}", hostname, e.getMessage(), e);
 			}
 		}
 		if(!rtn && doSocketTest && port != null) {
@@ -76,8 +79,8 @@ public class ConnectionUtils {
 					testSocket.setSoTimeout(soTimeout);
 					testSocket.connect(new InetSocketAddress(hostname, port), soTimeout);
 					rtn = true;
-				} catch(Exception ignored) {
-//					log.debug("host connectivity proxy check failed ${hostname} ${port} - ${ex.getMessage()}")
+				} catch(Exception e) {
+					log.debug("host connectivity proxy check failed {} {} - {}", hostname, port, e.getMessage(), e);
 				} finally {
 					if(testSocket != null) { try{ testSocket.close();} catch(Exception eb){}}
 				}
@@ -89,8 +92,8 @@ public class ConnectionUtils {
 					testSocket.setSoTimeout(soTimeout);
 					testSocket.connect(new InetSocketAddress(hostname, port), soTimeout);
 					rtn = true;
-				} catch(Exception ignored) {
-//					log.debug("host connectivity check failed ${hostname} ${port} - ${ex.getMessage()}")
+				} catch(Exception e) {
+					log.debug("host connectivity check failed {} {} - {}", hostname, port, e.getMessage(), e);
 				} finally {
 					if(testSocket != null) { try{ testSocket.close();} catch(Exception eb){}}
 				}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/MorpheusUtils.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/MorpheusUtils.java
@@ -438,7 +438,7 @@ public class MorpheusUtils {
 
 	static BigDecimal parseStringBigDecimal(String str, BigDecimal defaultValue) {
 		BigDecimal rtn = defaultValue;
-		try { rtn = new BigDecimal(str); } catch(Exception e) {}
+		try { rtn = new BigDecimal(str); } catch(Exception e) { log.debug("unable to parse '{}' as BigDecimal - {}", str, e.getMessage(), e); }
 		return rtn;
 	}
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/NetworkUtility.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/util/NetworkUtility.java
@@ -452,7 +452,9 @@ public class NetworkUtility {
 		String address = ipv6String.toSequentialRange().getUpper().toCanonicalString();
 		try {
 			address = normalizeIpAddress(address);
-		} catch(UnknownHostException ignored) {}
+		} catch(UnknownHostException e) {
+			log.debug("unable to normalize ip end address from cidr {} - {}", cidr, e.getMessage(), e);
+		}
 		return address;
 	}
 
@@ -461,7 +463,9 @@ public class NetworkUtility {
 		String address = ipv6String.toSequentialRange().getLower().toCanonicalString();
 		try {
 			address = normalizeIpAddress(address);
-		} catch(UnknownHostException ignored) {}
+		} catch(UnknownHostException e) {
+			log.debug("unable to normalize ip start address from cidr {} - {}", cidr, e.getMessage(), e);
+		}
 		return address;
 	}
 

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/MorpheusModel.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/MorpheusModel.java
@@ -149,7 +149,9 @@ public class MorpheusModel implements Serializable {
 				Object value = null;
 				try {
 					value = field.get(this);
-				} catch (IllegalAccessException ignore) { }
+				} catch (IllegalAccessException e) {
+					log.debug("unable to read field {} via reflection - {}", name, e.getMessage(), e);
+				}
 				map.put(name, value);
 			}
 		}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/MorpheusIdentityModel.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/projection/MorpheusIdentityModel.java
@@ -18,6 +18,8 @@ package com.morpheusdata.model.projection;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.morpheusdata.model.MorpheusModel;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.lang.reflect.Field;
 import java.util.*;
@@ -27,6 +29,7 @@ import java.util.*;
  * @author bdwheeler
  */
 public class MorpheusIdentityModel extends MorpheusModel {
+	static Logger log = LoggerFactory.getLogger(MorpheusIdentityModel.class);
 
 	static final String CONFIG_FIELD = "config";
 
@@ -44,7 +47,9 @@ public class MorpheusIdentityModel extends MorpheusModel {
 					Object value = null;
 					try {
 						value = field.get(this);
-					} catch(IllegalAccessException ignore) { }
+					} catch(IllegalAccessException e) {
+						log.debug("unable to read field {} via reflection - {}", name, e.getMessage(), e);
+					}
 					map.put(name, value);
 				}
 			}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/views/HandlebarsRenderer.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/views/HandlebarsRenderer.java
@@ -28,12 +28,15 @@ import com.morpheusdata.core.web.MorpheusWebRequestService;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.LinkedHashMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * HandlebarsRenderer implements the Renderer interface.
  * It uses a Dynamic template loader and Handlebars engine to render templates.
  */
 public class HandlebarsRenderer implements Renderer<Handlebars> {
+	static Logger log = LoggerFactory.getLogger(HandlebarsRenderer.class);
 	private final Handlebars engine;
 	private DynamicTemplateLoader loader;
 
@@ -150,7 +153,7 @@ public class HandlebarsRenderer implements Renderer<Handlebars> {
 	 * @return 400 HTTP response
 	 */
 	private HTMLResponse handleError(Exception e) {
-		e.printStackTrace();
+		log.error("Error rendering template: {}", e.getMessage(), e);
 		HTMLResponse response  = new HTMLResponse();
 		if (FileNotFoundException.class.equals(e.getClass())) {
 			response.html = "Template file not found: " + e.getMessage();

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/web/Dispatcher.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/web/Dispatcher.java
@@ -25,12 +25,15 @@ import com.morpheusdata.views.ViewModel;
 
 import java.lang.reflect.Method;
 import java.util.*;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Dispatcher provides a way for a plugin to handle routes from morpheus-ui to a plugin.
  * A Plugin may render html or json response back to the client.
  */
 public class Dispatcher {
+	static Logger log = LoggerFactory.getLogger(Dispatcher.class);
 	private final PluginManager pluginManager;
 
 	public Dispatcher(PluginManager pluginManager) {
@@ -102,7 +105,7 @@ public class Dispatcher {
 			}
 			return result;
 		} catch (Exception e) {
-			e.printStackTrace();
+			log.error("Error dispatching to {}.{} - {}", controller.getClass().getName(), methodName, e.getMessage(), e);
 		}
 		return null;
 	}


### PR DESCRIPTION
## Summary

Addresses two items from a broader `morpheus-plugin-api` code review (silent/inconsistent error handling):

- **Replace `println`/`printStackTrace` with SLF4J logging** in `PluginManager`, `Plugin`, `Dispatcher`, and `HandlebarsRenderer`. Plugin load failures and dispatch/render errors were only visible on stdout; they now go through structured logging (`log.info`/`log.warn`/`log.error`), adding a logger where one didn't already exist.
- **Add debug-level logging to previously silent catch blocks** in `ConnectionUtils`, `NetworkUtility`, `MorpheusUtils`, `MorpheusModel`, and `MorpheusIdentityModel` — host connectivity checks, CIDR address normalization, `BigDecimal` parsing fallback, and reflective field access. These failures were being swallowed entirely with no way to diagnose them.

`SecurityGroupRule`'s port-range parsing catch blocks were intentionally left untouched — the `NumberFormatException` there is expected control flow (falls through to range-splitting logic for values like `"80-443"`), not an error worth logging.

## Compatibility

No public API signatures or behavior changed — this is purely additive observability. Safe for all existing plugin consumers.

## Testing

`./gradlew morpheus-plugin-api:test` (Java 17) — build green, all specs passing.
