### PR TITLE
MORPH-14544: expose shareOptionTypes on StorageServerType (QA follow-up to morpheus-ui #4960)

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageServerType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/StorageServerType.java
@@ -50,7 +50,7 @@ public class StorageServerType extends MorpheusModel {
 	// Collection<OptionType> groupOptionTypes;
 	Collection<StorageVolumeType> volumeTypes;
 	Collection<OptionType> bucketOptionTypes;
-	// Collection<OptionType> shareOptionTypes;
+	Collection<OptionType> shareOptionTypes;
 	// Collection<OptionType> shareAccessOptionTypes;
 
 	public String getCode() {
@@ -294,5 +294,14 @@ public class StorageServerType extends MorpheusModel {
 	public void setBucketOptionTypes(Collection<OptionType> bucketOptionTypes) {
 		markDirty("bucketOptionTypes", this.bucketOptionTypes);
 		this.bucketOptionTypes = bucketOptionTypes;
+	}
+
+	public Collection<OptionType> getShareOptionTypes() {
+		return shareOptionTypes;
+	}
+
+	public void setShareOptionTypes(Collection<OptionType> shareOptionTypes) {
+		markDirty("shareOptionTypes", this.shareOptionTypes);
+		this.shareOptionTypes = shareOptionTypes;
 	}
 }

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/model/StorageServerTypeSpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/model/StorageServerTypeSpec.groovy
@@ -1,0 +1,46 @@
+package com.morpheusdata.model
+
+import spock.lang.Specification
+
+class StorageServerTypeSpec extends Specification {
+
+	void "setShareOptionTypes stores value and marks property dirty"() {
+		given:
+		def type = new StorageServerType()
+		def optionTypes = [new OptionType(name: 'Storage Server'), new OptionType(name: 'File Share')]
+
+		when:
+		type.setShareOptionTypes(optionTypes)
+
+		then: 'the getter round-trips the value (this is what the ui sync loop reads)'
+		type.getShareOptionTypes() == optionTypes
+
+		and: 'the property is flagged dirty so it is persisted (same contract as bucketOptionTypes)'
+		type.isDirty('shareOptionTypes')
+	}
+
+	void "setShareOptionTypes follows the same dirty contract as bucketOptionTypes"() {
+		given:
+		def type = new StorageServerType()
+		def shares = [new OptionType(name: 'File Share')]
+		def buckets = [new OptionType(name: 'Bucket')]
+
+		when:
+		type.setBucketOptionTypes(buckets)
+		type.setShareOptionTypes(shares)
+
+		then: 'both accessors behave identically'
+		type.getBucketOptionTypes() == buckets
+		type.getShareOptionTypes() == shares
+		type.isDirty('bucketOptionTypes')
+		type.isDirty('shareOptionTypes')
+	}
+
+	void "getShareOptionTypes returns null before it is set"() {
+		given:
+		def type = new StorageServerType()
+
+		expect:
+		type.getShareOptionTypes() == null
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to **MORPH-14544**, addressing **QA feedback** on the already-merged morpheus-ui fix ([HPE-EMU/morpheus-ui#4960](https://github.com/HPE-EMU/morpheus-ui/pull/4960)).

QA (Shrikant Joshi) verified that the merged morpheus-ui change was **necessary but not sufficient**: the File Share registration modal still returns **HTTP 500** for plugin-backed storage server types because of a second, upstream blocker in `morpheus-plugin-api`.

## Root cause

`morpheus-ui`'s `StorageProviderPluginManagerService` sync loop now includes `shareOptionTypes` and calls `storageServerTypeModel.getShareOptionTypes()` on the plugin-api `StorageServerType` model. In this repo that field and its accessors were commented out, so:

- `getShareOptionTypes()` did not exist / returned null
- nothing was persisted to `storage_server_type_share_option_type`
- `storageShares/_form.gsp` gate (`shareOptionTypes?.size() > 0`) stayed false → fell through to a non-existent template → `MissingViewException` → **HTTP 500**

## Change

Minimal, one-model change mirroring the existing `bucketOptionTypes` pattern in `StorageServerType.java`:

- Uncomment the `shareOptionTypes` association field
- Add `getShareOptionTypes()` / `setShareOptionTypes()` (with `markDirty`)

`shareAccessOptionTypes` is intentionally left as-is — out of scope for this defect.

## Testing

- `./gradlew :morpheus-plugin-api:compileJava` — compiles cleanly (only pre-existing deprecation warnings).
- **Unit test added:** `StorageServerTypeSpec` (mirrors the existing `NetworkRouterSpec` pattern) — **3/3 passing**. Covers exactly the accessor QA found missing:
  - `getShareOptionTypes()` round-trips the value the ui sync loop reads
  - `setShareOptionTypes()` marks the property dirty (same contract as `bucketOptionTypes`)
  - getter returns `null` before it is set
  - Run: `./gradlew :morpheus-plugin-api:test --tests com.morpheusdata.model.StorageServerTypeSpec` (JDK 17)
- **Scope note:** this proves the plugin-api layer QA flagged. The full HTTP-500 → modal-renders flow is not exercised here — it requires the published plugin-api jar + the HpeAlletraMp plugin + a running morpheus-ui/MySQL appliance, and is re-verified in QA's environment alongside the merged morpheus-ui #4960.

> CI note: this repo targets Java 11 and its Groovy test compiler cannot parse class files from JDK 25 (`Unsupported class file major version 69`). Build/test with JDK 17 (`JAVA_HOME`), not the SDKMAN Java 25 default.

## References

- Jira: MORPH-14544
- Paired morpheus-ui fix (merged): HPE-EMU/morpheus-ui#4960

