### PR TITLE
feat: add MorpheusSynchronousVirtualSwitchService for sync context ac…

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/network/MorpheusSynchronousNetworkService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/network/MorpheusSynchronousNetworkService.java
@@ -106,6 +106,14 @@ public interface MorpheusSynchronousNetworkService extends MorpheusSynchronousDa
 	MorpheusSynchronousNetworkLocationService getLocation();
 
 	/**
+	 * Returns the {@link MorpheusSynchronousVirtualSwitchService} used for performing updates/queries on
+	 * {@link com.morpheusdata.model.VirtualSwitch} related assets within Morpheus.
+	 * @return An instance of the {@link MorpheusSynchronousVirtualSwitchService}
+	 * @since 1.5.0
+	 */
+	MorpheusSynchronousVirtualSwitchService getVirtualSwitch();
+
+	/**
 	 * Validates an update on a {@link NetworkServer} before executing the update.
 	 * @deprecated use {@link MorpheusSynchronousNetworkServerService#validateUpdate(UpdateDefinition, NetworkServer)}  instead
 	 */

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/network/MorpheusSynchronousVirtualSwitchService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/network/MorpheusSynchronousVirtualSwitchService.java
@@ -1,0 +1,31 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.synchronous.network;
+
+import com.morpheusdata.core.MorpheusSynchronousDataService;
+import com.morpheusdata.core.MorpheusSynchronousIdentityService;
+import com.morpheusdata.model.VirtualSwitch;
+import com.morpheusdata.model.projection.VirtualSwitchIdentityProjection;
+
+/**
+ * Synchronous service interface for interacting with {@link VirtualSwitch} objects in a blocking fashion.
+ * Provides standard CRUD and sync identity projection listing.
+ *
+ * @since 1.5.0
+ */
+public interface MorpheusSynchronousVirtualSwitchService extends MorpheusSynchronousDataService<VirtualSwitch, VirtualSwitchIdentityProjection>, MorpheusSynchronousIdentityService<VirtualSwitchIdentityProjection> {
+}


### PR DESCRIPTION
…cess

Expose VirtualSwitch via the synchronous network service so plugins can access it through context.services.network.virtualSwitch (blocking API).