### PR TITLE
feat: expose VirtualSwitchSegment and VirtualSwitchUplink service APIs

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/MorpheusVirtualSwitchSegmentService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/MorpheusVirtualSwitchSegmentService.java
@@ -1,0 +1,42 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.network;
+
+import com.morpheusdata.core.MorpheusDataService;
+import com.morpheusdata.model.VirtualSwitchSegment;
+import io.reactivex.rxjava3.core.Observable;
+
+/**
+ * Context/service for querying and managing {@link VirtualSwitchSegment} objects.
+ * Provides standard CRUD operations for traffic segments within a VirtualSwitch.
+ *
+ * <p>Access via:</p>
+ * <pre>{@code
+ * morpheusContext.getNetwork().getVirtualSwitch().getSegment()
+ * }</pre>
+ *
+ * @since 1.5.0
+ */
+public interface MorpheusVirtualSwitchSegmentService extends MorpheusDataService<VirtualSwitchSegment, VirtualSwitchSegment> {
+
+	/**
+	 * List all segments belonging to a specific VirtualSwitch.
+	 * @param virtualSwitchId the ID of the parent VirtualSwitch
+	 * @return Observable stream of VirtualSwitchSegment
+	 */
+	Observable<VirtualSwitchSegment> listByVirtualSwitchId(Long virtualSwitchId);
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/MorpheusVirtualSwitchService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/MorpheusVirtualSwitchService.java
@@ -29,4 +29,17 @@ import com.morpheusdata.model.projection.VirtualSwitchIdentityProjection;
  */
 public interface MorpheusVirtualSwitchService extends MorpheusDataService<VirtualSwitch, VirtualSwitchIdentityProjection>, MorpheusIdentityService<VirtualSwitchIdentityProjection> {
 
+	/**
+	 * Returns the {@link MorpheusVirtualSwitchSegmentService} for managing traffic segments.
+	 * @return An instance of the Segment service
+	 * @since 1.5.0
+	 */
+	MorpheusVirtualSwitchSegmentService getSegment();
+
+	/**
+	 * Returns the {@link MorpheusVirtualSwitchUplinkService} for managing per-host uplinks.
+	 * @return An instance of the Uplink service
+	 * @since 1.5.0
+	 */
+	MorpheusVirtualSwitchUplinkService getUplink();
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/MorpheusVirtualSwitchUplinkService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/network/MorpheusVirtualSwitchUplinkService.java
@@ -1,0 +1,49 @@
+/*
+ *  Copyright 2024 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.core.network;
+
+import com.morpheusdata.core.MorpheusDataService;
+import com.morpheusdata.model.VirtualSwitchUplink;
+import io.reactivex.rxjava3.core.Observable;
+
+/**
+ * Context/service for querying and managing {@link VirtualSwitchUplink} objects.
+ * Provides standard CRUD operations for per-host uplink mappings within a VirtualSwitch.
+ *
+ * <p>Access via:</p>
+ * <pre>{@code
+ * morpheusContext.getNetwork().getVirtualSwitch().getUplink()
+ * }</pre>
+ *
+ * @since 1.5.0
+ */
+public interface MorpheusVirtualSwitchUplinkService extends MorpheusDataService<VirtualSwitchUplink, VirtualSwitchUplink> {
+
+	/**
+	 * List all uplinks belonging to a specific VirtualSwitch.
+	 * @param virtualSwitchId the ID of the parent VirtualSwitch
+	 * @return Observable stream of VirtualSwitchUplink
+	 */
+	Observable<VirtualSwitchUplink> listByVirtualSwitchId(Long virtualSwitchId);
+
+	/**
+	 * List all uplinks for a specific server (across all switches).
+	 * @param serverId the ID of the ComputeServer
+	 * @return Observable stream of VirtualSwitchUplink
+	 */
+	Observable<VirtualSwitchUplink> listByServerId(Long serverId);
+}


### PR DESCRIPTION
Add MorpheusVirtualSwitchSegmentService and MorpheusVirtualSwitchUplinkService interfaces so plugins can directly query/manage segments and uplinks.

- MorpheusVirtualSwitchSegmentService: CRUD + listByVirtualSwitchId()
- MorpheusVirtualSwitchUplinkService: CRUD + listByVirtualSwitchId() + listByServerId()
- Added getSegment()/getUplink() accessors to MorpheusVirtualSwitchService