### PR TITLE
Fail release fast when the project version does not match the release tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,6 +30,19 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           ref: rel-${{ steps.release_version.outputs.value }}
+      - name: "Verify project version matches the release tag"
+        env:
+          RELEASE_VERSION: ${{ steps.release_version.outputs.value }}
+        run: |
+          PROJECT_VERSION="$(sed -n 's/^[[:space:]]*version[[:space:]]*=[[:space:]]*//p' gradle.properties | tr -d '[:space:]')"
+          echo "Tag version:     ${RELEASE_VERSION}"
+          echo "Project version: ${PROJECT_VERSION}"
+          if [ "${PROJECT_VERSION}" != "${RELEASE_VERSION}" ]; then
+            echo "::error::gradle.properties declares version '${PROJECT_VERSION}' but the release tag is 'rel-${RELEASE_VERSION}'."
+            echo "::error::Bump 'version' in gradle.properties to '${RELEASE_VERSION}' and re-cut the tag on that commit."
+            echo "::error::A '-SNAPSHOT' version disables the nexus-publish plugin in build.gradle, so the Sonatype publish tasks are never created."
+            exit 1
+          fi
       - name: "Ensure Common Build Date"
         run: echo "SOURCE_DATE_EPOCH=$(git log -1 --pretty=%ct)" >> "$GITHUB_ENV"
       - name: "Ensure source files use common date"


### PR DESCRIPTION
The `rel-1.4.2` release [failed](https://github.com/HewlettPackard/morpheus-plugin-core/actions/runs/30565443451) with:

> Cannot locate tasks that match `morpheus-plugin-api:publishMavenPublicationToSonatypeRepository` as task `publishMavenPublicationToSonatypeRepository` not found in project `:morpheus-plugin-api`.

The tag was cut on a commit where `gradle.properties` still declared `version=1.4.2-SNAPSHOT`. Root `build.gradle` only applies `io.github.gradle-nexus.publish-plugin` when the version is not a snapshot, so the `sonatype` repository is never registered and the publish tasks the workflow invokes are never generated.

Nothing else differs between `rel-1.4.1` and `rel-1.4.2` — `build.gradle`, `settings.gradle`, `morpheus-plugin-api/build.gradle` and `release.yml` are byte-identical. `rel-1.4.1` was tagged on a "1.4.1 release" commit that dropped the suffix; `rel-1.4.2` was tagged on a plain feature commit.

This adds a check right after checkout that the version in `gradle.properties` matches the release tag, so a mis-cut tag fails in seconds with a message naming the cause, rather than 30 seconds in with an opaque missing-task error.

Exact match rather than a bare `-SNAPSHOT` check, so it also catches tagging `rel-1.4.3` on a commit still reading `1.4.2`.

Does not change `gradle.properties` — bumping the version and re-cutting `rel-1.4.2` is a separate operational step on `v1.4.x`.
