### PR TITLE
Add backup job capability flags to the plugin API

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/BackupProviderInterface.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/backup/BackupProviderInterface.java
@@ -388,4 +388,23 @@ public interface BackupProviderInterface extends PluginProvider, UIExtensionProv
 	default HTMLResponse renderTemplate(com.morpheusdata.model.BackupProvider backupProvider) {
 		return null;
 	}
+
+	/**
+	 * The backup provider supports editing an existing job.
+	 * @return true if the backup provider supports editing an existing job, false otherwise
+	 */
+	default Boolean getHasEditJob() { return true; }
+
+	/**
+	 * The backup provider supports running a job directly.
+	 * @return true if the backup provider supports running a job, false otherwise
+	 */
+	default Boolean getHasRunJob() { return true; }
+
+	/**
+	 * The backup job code may be defined and edited by the user. Providers that own the job code externally, such as
+	 * integrations that mirror jobs from a remote system, should return false so the field is rendered read-only.
+	 * @return true if the job code is user editable, false if the provider owns it
+	 */
+	default Boolean getHasEditableJobCode() { return true; }
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/BackupProviderType.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/BackupProviderType.java
@@ -53,6 +53,9 @@ public class BackupProviderType extends MorpheusModel {
 	protected Boolean hasStorageProvider = true;
 	protected Boolean hasRetentionCount = true;
 	protected Boolean hasCancelBackup = true;
+	protected Boolean hasEditJob = true;
+	protected Boolean hasRunJob = true;
+	protected Boolean hasEditableJobCode = true;
 
 	protected Boolean isPlugin;
 
@@ -308,6 +311,33 @@ public class BackupProviderType extends MorpheusModel {
 	public void setHasCancelBackup(Boolean hasCancelBackup) {
 		markDirty("hasCancelBackup", hasCancelBackup, this.hasCancelBackup);
 		this.hasCancelBackup = hasCancelBackup;
+	}
+
+	public Boolean getHasEditJob() {
+		return hasEditJob;
+	}
+
+	public void setHasEditJob(Boolean hasEditJob) {
+		markDirty("hasEditJob", hasEditJob, this.hasEditJob);
+		this.hasEditJob = hasEditJob;
+	}
+
+	public Boolean getHasRunJob() {
+		return hasRunJob;
+	}
+
+	public void setHasRunJob(Boolean hasRunJob) {
+		markDirty("hasRunJob", hasRunJob, this.hasRunJob);
+		this.hasRunJob = hasRunJob;
+	}
+
+	public Boolean getHasEditableJobCode() {
+		return hasEditableJobCode;
+	}
+
+	public void setHasEditableJobCode(Boolean hasEditableJobCode) {
+		markDirty("hasEditableJobCode", hasEditableJobCode, this.hasEditableJobCode);
+		this.hasEditableJobCode = hasEditableJobCode;
 	}
 
 	public Boolean getPlugin() {


### PR DESCRIPTION
Backup providers had no way to declare whether they support editing a job, running a job on demand, or whether the job code is externally owned. The UI compensated with hardcoded vendor-name checks, which meant plugins could not describe their own behavior.

Adds hasEditJob, hasRunJob and hasEditableJobCode to BackupProviderInterface and the BackupProviderType model. Existing binding picks these up automatically, so no manager-service change is required.

Declared as boxed Boolean to match every other capability getter; a primitive would prevent plugin authors from overriding them.