### PR TITLE
MOPRH-14527 :: Add plugin-core interface for basis of plugin api method to create AccountCredentialLinks

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusAccountCredentialService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusAccountCredentialService.java
@@ -16,13 +16,7 @@
 
 package com.morpheusdata.core;
 
-import com.morpheusdata.model.AccountCredential;
-import com.morpheusdata.model.AccountIntegration;
-import com.morpheusdata.model.BackupProvider;
-import com.morpheusdata.model.Cloud;
-import com.morpheusdata.model.ComputeServer;
-import com.morpheusdata.model.NetworkServer;
-import com.morpheusdata.model.StorageServer;
+import com.morpheusdata.model.*;
 import com.morpheusdata.model.projection.AccountCredentialIdentityProjection;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.core.Maybe;
@@ -77,4 +71,14 @@ public interface MorpheusAccountCredentialService extends MorpheusDataService<Ac
 	 * @return Maybe emitting the AccountCredential with data populated, or empty if no link exists
 	 */
 	Maybe<AccountCredential> loadCredentials(NetworkServer networkServer);
+
+	/**
+	 * Creates a credential link for a specified credential and associated ref information and returns the created link.
+	 * @param credential the credential to create the link for.
+	 * @param refType The resource type the link will be used by.
+	 * @param refUuid The uuid for the resource the link will be used by.
+	 * @param refName The name of the resource the link will be used by.
+	 * @return Maybe emitting the AccountCredentialLink that was created.
+	 */
+	Maybe<AccountCredentialLink> createCredentialLink(AccountCredential credential, String refType, String refUuid, String refName);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusAccountCredentialService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/MorpheusAccountCredentialService.java
@@ -18,6 +18,7 @@ package com.morpheusdata.core;
 
 import com.morpheusdata.model.*;
 import com.morpheusdata.model.projection.AccountCredentialIdentityProjection;
+import com.morpheusdata.response.ServiceResponse;
 import io.reactivex.rxjava3.core.Single;
 import io.reactivex.rxjava3.core.Maybe;
 
@@ -78,7 +79,7 @@ public interface MorpheusAccountCredentialService extends MorpheusDataService<Ac
 	 * @param refType The resource type the link will be used by.
 	 * @param refUuid The uuid for the resource the link will be used by.
 	 * @param refName The name of the resource the link will be used by.
-	 * @return Maybe emitting the AccountCredentialLink that was created.
+	 * @return ServiceResponse possibly containing a created AccountCredentialLink.
 	 */
-	Maybe<AccountCredentialLink> createCredentialLink(AccountCredential credential, String refType, String refUuid, String refName);
+	Single<ServiceResponse<AccountCredentialLink>> createCredentialLink(AccountCredential credential, String refType, String refUuid, String refName);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousAccountCredentialService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousAccountCredentialService.java
@@ -18,13 +18,7 @@ package com.morpheusdata.core.synchronous;
 
 import com.morpheusdata.core.MorpheusSynchronousIdentityService;
 import com.morpheusdata.core.MorpheusSynchronousDataService;
-import com.morpheusdata.model.AccountCredential;
-import com.morpheusdata.model.AccountIntegration;
-import com.morpheusdata.model.BackupProvider;
-import com.morpheusdata.model.Cloud;
-import com.morpheusdata.model.ComputeServer;
-import com.morpheusdata.model.NetworkServer;
-import com.morpheusdata.model.StorageServer;
+import com.morpheusdata.model.*;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 
@@ -53,4 +47,6 @@ public interface MorpheusSynchronousAccountCredentialService extends MorpheusSyn
 	AccountCredential loadCredentials(StorageServer storageServer);
 
 	AccountCredential loadCredentials(NetworkServer networkServer);
+
+	AccountCredentialLink createCredentialLink(AccountCredential credential, String refType, String refUuid, String refName);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousAccountCredentialService.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/synchronous/MorpheusSynchronousAccountCredentialService.java
@@ -19,6 +19,7 @@ package com.morpheusdata.core.synchronous;
 import com.morpheusdata.core.MorpheusSynchronousIdentityService;
 import com.morpheusdata.core.MorpheusSynchronousDataService;
 import com.morpheusdata.model.*;
+import com.morpheusdata.response.ServiceResponse;
 import io.reactivex.rxjava3.core.Maybe;
 import io.reactivex.rxjava3.core.Single;
 
@@ -48,5 +49,5 @@ public interface MorpheusSynchronousAccountCredentialService extends MorpheusSyn
 
 	AccountCredential loadCredentials(NetworkServer networkServer);
 
-	AccountCredentialLink createCredentialLink(AccountCredential credential, String refType, String refUuid, String refName);
+	ServiceResponse<AccountCredentialLink> createCredentialLink(AccountCredential credential, String refType, String refUuid, String refName);
 }

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/AccountCredentialLink.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/AccountCredentialLink.java
@@ -1,0 +1,43 @@
+/*
+ *  Copyright 2026 Morpheus Data, LLC.
+ *
+ * Licensed under the PLUGIN CORE SOURCE LICENSE (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://raw.githubusercontent.com/gomorpheus/morpheus-plugin-core/v1.0.x/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.morpheusdata.model;
+
+import com.morpheusdata.model.projection.AccountCredentialIdentityProjection;
+
+import java.util.Date;
+
+public class AccountCredentialLink extends AccountCredentialIdentityProjection {
+	protected AccountCredential credential;
+
+	//ownership
+	protected Account account;
+
+	protected User user;
+	protected UserGroup group;
+	protected Role role;
+	protected Boolean defaultCredential;
+
+	//ref
+	protected String refType;
+	protected String refUuid;
+	protected String refName;
+
+	//audit
+	protected Date dateCreated;
+	protected Date lastUpdated;
+
+}

--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/model/AccountCredentialLink.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/model/AccountCredentialLink.java
@@ -29,7 +29,7 @@ public class AccountCredentialLink extends AccountCredentialIdentityProjection {
 	protected User user;
 	protected UserGroup group;
 	protected Role role;
-	protected Boolean defaultCredential;
+	protected Boolean defaultCredential = false;
 
 	//ref
 	protected String refType;
@@ -39,5 +39,93 @@ public class AccountCredentialLink extends AccountCredentialIdentityProjection {
 	//audit
 	protected Date dateCreated;
 	protected Date lastUpdated;
+
+	public AccountCredential getCredential() {
+		return credential;
+	}
+
+	public void setCredential(AccountCredential newCredential) {
+		credential = newCredential;
+	}
+
+	public Account getAccount() {
+		return account;
+	}
+
+	public void setAccount(Account newAccount){
+		account = newAccount;
+	}
+
+	public User getUser() {
+		return user;
+	}
+
+	public void setUser(User newUser){
+		user = newUser;
+	}
+
+	public UserGroup getGroup() {
+		return group;
+	}
+
+	public void setGroup(UserGroup newGroup){
+		group = newGroup;
+	}
+
+	public Role getRole() {
+		return role;
+	}
+
+	public void setRole(Role newRole){
+		role = newRole;
+	}
+
+	public Boolean getDefaultCredential() {
+		return defaultCredential;
+	}
+
+	public void setDefaultCredential(Boolean newDefaultCredential) {
+		defaultCredential = newDefaultCredential;
+	}
+
+	public String getRefType() {
+		return refType;
+	}
+
+	public void setRefType(String newRefType) {
+		refType = newRefType;
+	}
+
+	public String getRefUuid() {
+		return refUuid;
+	}
+
+	public void setRefUuid(String newRefUuid) {
+		refUuid = newRefUuid;
+	}
+
+	public String getRefName() {
+		return refName;
+	}
+
+	public void setRefName(String newRefName) {
+		refName = newRefName;
+	}
+
+	public Date getDateCreated() {
+		return dateCreated;
+	}
+
+	public void setDateCreated(Date newDateCreated) {
+		dateCreated = newDateCreated;
+	}
+
+	public Date getLastUpdated() {
+		return lastUpdated;
+	}
+
+	public void setLastUpdated(Date newLastUpdated) {
+		lastUpdated = newLastUpdated;
+	}
 
 }


### PR DESCRIPTION
Adding interface details to plugin-core, which will allow implementation of a plugin-api function to create new AccountCredentialLinks given a credential and the related ref information (name, uuid, and type).

This is the basis for the implementation for [MORPH-14527](https://hpe.atlassian.net/browse/MORPH-14527), and is necessary for the functioning of the morpheus-ui repo changes in [PR 5264](https://github.com/HPE-EMU/morpheus-ui/pull/5264).