### PR TITLE
Add default no-op validateFileShare to StorageProviderFileShares

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderFileShares.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderFileShares.java
@@ -31,6 +31,22 @@ import java.util.Map;
  * @see StorageProvider
  */
 public interface StorageProviderFileShares {
+
+	/**
+	 * Validates the submitted information when saving a file share.
+	 * This is invoked before both {@link #createFileShare} and {@link #updateFileShare}.
+	 * @param storageShare Storage Bucket (file share) information
+	 * @param opts additional options
+	 * @return a {@link ServiceResponse} object. The errors field of the ServiceResponse is used to send validation
+	 * results back to the interface in the format of {@code errors['fieldName'] = 'validation message' }. The msg
+	 * property can be used to send generic validation text that is not related to a specific field on the model.
+	 * A ServiceResponse with a success value of 'false' will halt the create/update process.
+	 * Defaults to a no-op success response so existing implementations do not need to override it.
+	 */
+	default ServiceResponse validateFileShare(StorageBucket storageShare, Map opts) {
+		return ServiceResponse.success();
+	}
+
 	ServiceResponse createFileShare(StorageBucket storageShare, Map opts);
 
 	ServiceResponse updateFileShare(StorageBucket storageShare, Map opts);

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/providers/StorageProviderFileSharesSpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/providers/StorageProviderFileSharesSpec.groovy
@@ -1,0 +1,41 @@
+package com.morpheusdata.core.providers
+
+import com.morpheusdata.model.StorageBucket
+import com.morpheusdata.response.ServiceResponse
+import spock.lang.Specification
+
+class StorageProviderFileSharesSpec extends Specification {
+
+	void "validateFileShare defaults to a no-op success response when not overridden"() {
+		given:
+		def provider = new MinimalFileShareProvider()
+
+		when:
+		def result = provider.validateFileShare(new StorageBucket(), [:])
+
+		then:
+		result.success
+	}
+
+	private static class MinimalFileShareProvider implements StorageProviderFileShares {
+		@Override
+		ServiceResponse createFileShare(StorageBucket storageShare, Map opts) {
+			return ServiceResponse.success()
+		}
+
+		@Override
+		ServiceResponse updateFileShare(StorageBucket storageShare, Map opts) {
+			return ServiceResponse.success()
+		}
+
+		@Override
+		ServiceResponse deleteFileShare(StorageBucket storageShare, Map opts) {
+			return ServiceResponse.success()
+		}
+
+		@Override
+		Collection<String> getFileShareProviderTypes() {
+			return []
+		}
+	}
+}

--- a/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
+++ b/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
@@ -2,6 +2,10 @@
 
 **Note:** Morpheus Plugin API is now 1.0! This means calls that are used will be supported for a longer period of time and given appropriate deprecation warnings when necessary. Morpheus Plugin API `1.3.x` requires a minimum Morpheus version of `8.1.x`. Morpheus Plugin API `1.2.x` requires Morpheus `8.0.x`, and Morpheus `7.0.x` runs on Core version `1.1.x`.
 
+* **1.5.1**
+** *Storage Provider File Share Validation*
+*** Added a `validateFileShare` default method to `StorageProviderFileShares`, defaulting to a no-op success response so existing implementations do not need to override it.
+
 * **1.4.0**
 ** *Option Type Enhancements*
 *** Added `MULTI_TEXT` to `OptionType.InputType` so plugins can define multi-value text inputs (MORPH-6011).


### PR DESCRIPTION
## Summary
Adds a default `validateFileShare(StorageBucket storageShare, Map opts)` method to `StorageProviderFileShares`, returning `ServiceResponse.success()` by default.

This mirrors the existing `validateBucket` contract on `StorageProviderBuckets`, giving plugins the ability to validate file share create/update requests before they are persisted, without requiring any changes from existing implementations (the default is a no-op success).

## Changes
- `StorageProviderFileShares.java`: added `default validateFileShare` method with javadoc.
- `StorageProviderFileSharesSpec.groovy`: new test verifying the default no-op success behavior.
- `ReleaseNotes.adoc`: documented the addition under `1.5.1`.

## Testing
- `./gradlew morpheus-plugin-api:test` — all tests pass (run with JDK 17).