### PR TITLE
Add default no-op syncFileShare/createFileShareAccess/deleteFileShareAccess

### DIFF
--- a/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderFileShares.java
+++ b/morpheus-plugin-api/src/main/java/com/morpheusdata/core/providers/StorageProviderFileShares.java
@@ -16,6 +16,7 @@
 
 package com.morpheusdata.core.providers;
 
+import com.morpheusdata.model.ReferenceData;
 import com.morpheusdata.model.StorageBucket;
 import com.morpheusdata.response.ServiceResponse;
 
@@ -52,6 +53,43 @@ public interface StorageProviderFileShares {
 	ServiceResponse updateFileShare(StorageBucket storageShare, Map opts);
 
 	ServiceResponse deleteFileShare(StorageBucket storageShare, Map opts);
+
+	/**
+	 * Synchronizes the state of a file share with the external provider system. This is invoked periodically to
+	 * reconcile any drift between the local record and the external system.
+	 * @param storageShare Storage Bucket (file share) information
+	 * @param opts additional options
+	 * @return a {@link ServiceResponse} indicating the results of the sync operation.
+	 * Defaults to a no-op success response so existing implementations do not need to override it.
+	 */
+	default ServiceResponse syncFileShare(StorageBucket storageShare, Map opts) {
+		return ServiceResponse.success();
+	}
+
+	/**
+	 * Creates an access rule (e.g. a host or network allowed to mount the share) on the external provider system.
+	 * @param storageShare Storage Bucket (file share) information
+	 * @param config the submitted access rule configuration
+	 * @param opts additional options
+	 * @return a {@link ServiceResponse} object. The {@code data} property can be populated with details about the
+	 * created access rule to be stored locally.
+	 * Defaults to a no-op success response so existing implementations do not need to override it.
+	 */
+	default ServiceResponse createFileShareAccess(StorageBucket storageShare, Map config, Map opts) {
+		return ServiceResponse.success();
+	}
+
+	/**
+	 * Deletes an access rule on the external provider system.
+	 * @param storageShare Storage Bucket (file share) information
+	 * @param fileShareAccess the access rule to be removed
+	 * @param opts additional options
+	 * @return a {@link ServiceResponse} indicating the results of the deletion on the external provider system.
+	 * Defaults to a no-op success response so existing implementations do not need to override it.
+	 */
+	default ServiceResponse deleteFileShareAccess(StorageBucket storageShare, ReferenceData fileShareAccess, Map opts) {
+		return ServiceResponse.success();
+	}
 
 	Collection<String> getFileShareProviderTypes();
 }

--- a/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/providers/StorageProviderFileSharesSpec.groovy
+++ b/morpheus-plugin-api/src/test/groovy/com/morpheusdata/core/providers/StorageProviderFileSharesSpec.groovy
@@ -1,5 +1,6 @@
 package com.morpheusdata.core.providers
 
+import com.morpheusdata.model.ReferenceData
 import com.morpheusdata.model.StorageBucket
 import com.morpheusdata.response.ServiceResponse
 import spock.lang.Specification
@@ -12,6 +13,39 @@ class StorageProviderFileSharesSpec extends Specification {
 
 		when:
 		def result = provider.validateFileShare(new StorageBucket(), [:])
+
+		then:
+		result.success
+	}
+
+	void "syncFileShare defaults to a no-op success response when not overridden"() {
+		given:
+		def provider = new MinimalFileShareProvider()
+
+		when:
+		def result = provider.syncFileShare(new StorageBucket(), [:])
+
+		then:
+		result.success
+	}
+
+	void "createFileShareAccess defaults to a no-op success response when not overridden"() {
+		given:
+		def provider = new MinimalFileShareProvider()
+
+		when:
+		def result = provider.createFileShareAccess(new StorageBucket(), [:], [:])
+
+		then:
+		result.success
+	}
+
+	void "deleteFileShareAccess defaults to a no-op success response when not overridden"() {
+		given:
+		def provider = new MinimalFileShareProvider()
+
+		when:
+		def result = provider.deleteFileShareAccess(new StorageBucket(), new ReferenceData(), [:])
 
 		then:
 		result.success

--- a/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
+++ b/morpheus-plugin-docs/src/docs/asciidoc/ReleaseNotes.adoc
@@ -3,8 +3,8 @@
 **Note:** Morpheus Plugin API is now 1.0! This means calls that are used will be supported for a longer period of time and given appropriate deprecation warnings when necessary. Morpheus Plugin API `1.3.x` requires a minimum Morpheus version of `8.1.x`. Morpheus Plugin API `1.2.x` requires Morpheus `8.0.x`, and Morpheus `7.0.x` runs on Core version `1.1.x`.
 
 * **1.5.1**
-** *Storage Provider File Share Validation*
-*** Added a `validateFileShare` default method to `StorageProviderFileShares`, defaulting to a no-op success response so existing implementations do not need to override it.
+** *Storage Provider File Share Enhancements*
+*** Added `validateFileShare`, `syncFileShare`, `createFileShareAccess`, and `deleteFileShareAccess` default methods to `StorageProviderFileShares`, each defaulting to a no-op success response so existing implementations do not need to override them.
 
 * **1.4.0**
 ** *Option Type Enhancements*


### PR DESCRIPTION
## Summary
Follow-up to #230. Extends `StorageProviderFileShares` with default no-op methods for `syncFileShare`, `createFileShareAccess`, and `deleteFileShareAccess` — the remaining file-share operations that a companion appliance-side fix needs to call, but which weren't previously defined on the interface at all.

## Changes
- Added `default syncFileShare(StorageBucket, Map)` returning `ServiceResponse.success()`.
- Added `default createFileShareAccess(StorageBucket, Map config, Map opts)` returning `ServiceResponse.success()`.
- Added `default deleteFileShareAccess(StorageBucket, ReferenceData, Map opts)` returning `ServiceResponse.success()`, using the existing `ReferenceData` model so plugins can resolve the external identifier of the access rule being removed.
- All three are backward-compatible no-ops; existing implementations of `StorageProviderFileShares` are unaffected.
- Added test coverage and a release notes entry.

## Testing
- `./gradlew morpheus-plugin-api:test` (JDK 17) — all tests pass.
